### PR TITLE
Frontend apply logic

### DIFF
--- a/frontend/src/store/core_table.ts
+++ b/frontend/src/store/core_table.ts
@@ -76,8 +76,6 @@ export function coreTableStoreFactory(): Module<
   };
 }
 
-export const CoreTableStore = coreTableStoreFactory();
-
 export function isRecommendationInResults(
   tableState: ICoreTableStoreState,
   recExtra: RecommendationExtra

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -315,5 +315,3 @@ export function recommendationStoreFactory(): Module<
     getters: getters
   };
 }
-
-export const RecommendationsStore = recommendationStoreFactory();

--- a/frontend/src/store/root.ts
+++ b/frontend/src/store/root.ts
@@ -15,14 +15,14 @@ limitations under the License. */
 import Vue from "vue";
 import Vuex, { StoreOptions, Store, GetterTree } from "vuex";
 import {
-  RecommendationsStore,
-  IRecommendationsStoreState
+  IRecommendationsStoreState,
+  recommendationStoreFactory
 } from "./recommendations";
 
 import {
-  CoreTableStore,
   ICoreTableStoreState,
-  isRecommendationInResults
+  isRecommendationInResults,
+  coreTableStoreFactory
 } from "./core_table";
 import { RecommendationExtra } from "./model";
 
@@ -52,8 +52,8 @@ export function rootStoreFactory(): Store<IRootStoreState> {
     state: {},
     getters: getters,
     modules: {
-      recommendationsStore: RecommendationsStore,
-      coreTableStore: CoreTableStore
+      recommendationsStore: recommendationStoreFactory(),
+      coreTableStore: coreTableStoreFactory()
     }
   };
   return new Store<IRootStoreState>(storeOptions);

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -141,7 +141,7 @@ describe("watchStatus action", () => {
     await watchStatus(context, firstRec);
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("CLAIMED"));
 
-    // end the status updates cycle
+    // dispatch watchStatus in the future
     expect(setTimeout as any).toBeCalledTimes(1);
   });
 
@@ -151,7 +151,7 @@ describe("watchStatus action", () => {
     expect((fetch as any).mock.calls[0][0].indexOf(firstRec.name)).not.toBe(-1);
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("SUCCEEDED"));
 
-    // dispatch watchStatus in the future
+    // end the status updates cycle
     expect(setTimeout as any).toBeCalledTimes(0);
   });
 

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -1,0 +1,199 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import { enableFetchMocks } from "jest-fetch-mock";
+import { RecommendationExtra, getInternalStatusMapping } from "@/store/model";
+import { freshSampleRawRecommendation } from "./sample_recommendation";
+import { rootStoreFactory } from "@/store/root";
+import { recommendationStoreFactory } from "@/store/recommendations";
+
+let store: any, context: any, commit: any;
+let dispatch: jest.Mock;
+
+let firstRec: RecommendationExtra;
+
+beforeAll(() => {
+  enableFetchMocks();
+  fetchMock.dontMock();
+});
+
+beforeEach(() => {
+  fetchMock.doMock();
+  store = rootStoreFactory();
+  const modState = store.state.recommendationsStore!;
+
+  // dispatch, commit are now spied on and do nothing
+  dispatch = jest.fn();
+  commit = (name: any, payload: any) => {
+    store.commit("recommendationsStore/" + name, payload);
+  };
+
+  context = {
+    dispatch: dispatch,
+    commit: commit,
+    state: modState
+  };
+
+  const recsRaw = [
+    freshSampleRawRecommendation(),
+    freshSampleRawRecommendation()
+  ];
+  recsRaw[0].name = "a/b";
+  recsRaw[1].name = "a/b/c";
+  store.commit("recommendationsStore/addRecommendation", recsRaw[0]);
+  store.commit("recommendationsStore/addRecommendation", recsRaw[1]);
+  firstRec = modState.recommendations[0];
+});
+
+afterEach(() => {
+  fetchMock.dontMock();
+  fetchMock.mockClear();
+  dispatch.mockClear();
+});
+
+test("applyGivenRecommendations action", () => {
+  const applier = recommendationStoreFactory().actions![
+    "applyGivenRecommendations"
+  ] as any;
+  expect(applier).not.toBeNull();
+
+  // duplicates
+  expect(() => {
+    applier(context, ["a/b", "a/b"]);
+  }).toThrowError();
+  expect(dispatch).toBeCalledTimes(0);
+
+  // non-existent
+  dispatch.mockReset();
+  expect(() => {
+    applier(context, ["a/b", "a/b/c/d"]);
+  }).toThrowError();
+  expect(dispatch).toBeCalledTimes(0);
+
+  dispatch.mockReset();
+  expect(() => {
+    applier(context, ["a/b/c", "a/b"]);
+  }).not.toThrowError();
+  expect(dispatch).toBeCalledTimes(2);
+  expect(dispatch.mock.calls[0][0]).toBe("applySingleRecommendation");
+  expect(dispatch.mock.calls[1][0]).toBe("applySingleRecommendation");
+  const passedRecNames = dispatch.mock.calls.map(call => call[1].name);
+  expect(passedRecNames).toContain("a/b/c");
+  expect(passedRecNames).toContain("a/b");
+});
+
+describe("applySingleRecommendation action", () => {
+  let applier: any;
+  beforeAll(() => {
+    applier = recommendationStoreFactory().actions![
+      "applySingleRecommendation"
+    ] as any;
+  });
+
+  test("success", async () => {
+    fetchMock.mockResponseOnce("");
+    await applier(context, firstRec);
+
+    expect((fetch as any).mock.calls.length).toEqual(1);
+    expect((fetch as any).mock.calls[0][0].indexOf(firstRec.name)).not.toBe(-1);
+    expect(dispatch.mock.calls).toEqual([["watchStatus", firstRec]]);
+    expect(firstRec.statusCol).toEqual(getInternalStatusMapping("CLAIMED"));
+  });
+
+  test("failure", async () => {
+    fetchMock.mockResponseOnce(async () => {
+      return { status: 404, body: "Endpoint not found" };
+    });
+    await applier(context, firstRec);
+
+    expect((fetch as any).mock.calls.length).toEqual(1);
+    expect(dispatch).toHaveBeenCalledTimes(0);
+    expect(firstRec.statusCol).toEqual(getInternalStatusMapping("FAILED"));
+    expect(firstRec.errorHeader).not.toBeNull();
+  });
+});
+
+describe("watchStatus action", () => {
+  let watchStatus: any;
+  beforeAll(() => {
+    watchStatus = recommendationStoreFactory().actions!["watchStatus"] as any;
+  });
+  beforeEach(() => {
+    jest.useFakeTimers(); // mocked setTimeout
+  });
+
+  test("-> in progress", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "IN PROGRESS" }));
+    await watchStatus(context, firstRec);
+    expect(firstRec.statusCol).toBe(getInternalStatusMapping("CLAIMED"));
+
+    // end the status updates cycle
+    expect(setTimeout as any).toBeCalledTimes(1);
+  });
+
+  test("-> succeeded", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "SUCCEEDED" }));
+    await watchStatus(context, firstRec);
+    expect((fetch as any).mock.calls[0][0].indexOf(firstRec.name)).not.toBe(-1);
+    expect(firstRec.statusCol).toBe(getInternalStatusMapping("SUCCEEDED"));
+
+    // dispatch watchStatus in the future
+    expect(setTimeout as any).toBeCalledTimes(0);
+  });
+
+  test("-> not applied", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "NOT APPLIED" }));
+    await watchStatus(context, firstRec);
+    expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
+    expect(firstRec.errorHeader!.startsWith("Server has")).toBeTruthy();
+
+    expect(setTimeout as any).toBeCalledTimes(0);
+  });
+
+  test("-> failed", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        status: "FAILED",
+        errorMessage: "something bad happened"
+      })
+    );
+    await watchStatus(context, firstRec);
+    expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
+    expect(firstRec.errorHeader!.startsWith("Applying ")).toBeTruthy();
+    expect(firstRec.errorDescription).toBe("something bad happened");
+
+    expect(setTimeout as any).toBeCalledTimes(0);
+  });
+
+  test("-> gibberish", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "%%%" }));
+    await watchStatus(context, firstRec);
+    expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
+    expect(firstRec.errorHeader!.startsWith("Bad status(")).toBeTruthy();
+
+    expect(setTimeout as any).toBeCalledTimes(0);
+  });
+
+  test("server connection error", async () => {
+    fetchMock.mockResponseOnce(async () => {
+      return { status: 404, body: "Endpoint not found" };
+    });
+    await watchStatus(context, firstRec);
+    expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
+    expect(firstRec.errorHeader?.indexOf("404")).not.toBe(-1);
+
+    // we want to try again in this case
+    expect(setTimeout as any).toBeCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -24,8 +24,8 @@ let dispatch: jest.Mock;
 let firstRec: RecommendationExtra;
 
 beforeAll(() => {
-  enableFetchMocks();
-  fetchMock.dontMock();
+  enableFetchMocks(); // fetchMock instance visible
+  fetchMock.dontMock(); // fetches only mocked at request
 });
 
 beforeEach(() => {
@@ -33,8 +33,10 @@ beforeEach(() => {
   store = rootStoreFactory();
   const modState = store.state.recommendationsStore!;
 
-  // dispatch, commit are now spied on and do nothing
+  // dispatch is now spied on and does nothing
   dispatch = jest.fn();
+
+  // commit is converted to module form
   commit = (name: any, payload: any) => {
     store.commit("recommendationsStore/" + name, payload);
   };
@@ -58,6 +60,7 @@ beforeEach(() => {
 
 afterEach(() => {
   fetchMock.dontMock();
+  // clear the spies
   fetchMock.mockClear();
   dispatch.mockClear();
 });

--- a/frontend/tests/unit/recommendations.spec.ts
+++ b/frontend/tests/unit/recommendations.spec.ts
@@ -72,7 +72,12 @@ describe("Fetching recommendations", () => {
 
     const sampleRecommendation = freshSampleRawRecommendation();
     responses.push(JSON.stringify({ recommendations: [sampleRecommendation] }));
-    fetchMock.mockResponses(...responses);
+    // use the just defined responses followed by 404s
+    fetchMock
+      .mockResponses(...responses)
+      .mockImplementation(async () =>
+        Promise.resolve(new Response("", { status: 404 }))
+      );
 
     const store = rootStoreFactory();
     store.commit("recommendationsStore/resetRecommendations");
@@ -108,7 +113,11 @@ describe("Fetching recommendations", () => {
     responses.push(
       JSON.stringify({ recommendations: [freshSampleRawRecommendation()] })
     );
-    fetchMock.mockResponses(...responses);
+    fetchMock
+      .mockResponses(...responses)
+      .mockImplementation(async () =>
+        Promise.resolve(new Response("", { status: 404 }))
+      );
     const store = rootStoreFactory();
     store.commit("recommendationsStore/resetRecommendations");
     await store.dispatch("recommendationsStore/fetchRecommendations");


### PR DESCRIPTION
- Handling 'apply' being clicked for one or more recommendations.
- Launching and running status watchers for recommendations (status watchers are launched at start for all 'CLAIMED' recommendations and whenever a recommendation is applied), converted from commented out code.
- Tests for both of these
- Also, fixed the root store factory to use module store factories instead of global constants. This caused some trouble for running multiple tests, as they shared some data.