### PR TITLE
Mobile-friendly view of filters

### DIFF
--- a/frontend/src/components/CoreTable.vue
+++ b/frontend/src/components/CoreTable.vue
@@ -25,8 +25,8 @@ limitations under the License. -->
   >
     <!-- ^customFilter prop is not used, because its implementation executes it for each property -->
 
-    <template v-slot:body.prepend>
-      <FiltersRow />
+    <template v-slot:body.prepend="{ isMobile }">
+      <FiltersRow :isMobile="isMobile" />
     </template>
 
     <template v-slot:item.resourceCol="{ item }">

--- a/frontend/src/components/FiltersRow.vue
+++ b/frontend/src/components/FiltersRow.vue
@@ -12,153 +12,69 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
 <template>
-  <tr>
+  <tr v-if="isMobile">
+    <td>
+      <ResourceFilter />
+      <ProjectFilter />
+      <TypeFilter />
+      <DescriptionFilter />
+      <CostFilter />
+      <StatusFilter />
+    </td>
+  </tr>
+
+  <tr v-else>
     <td />
     <td class="pb-5">
-      <v-text-field
-        v-model="resourceNameSearchText"
-        append-icon="mdi-magnify"
-        label="Search resources"
-        single-line
-        hide-details
-      />
+      <ResourceFilter />
     </td>
     <td>
-      <v-combobox
-        v-model="projectsSelected"
-        :items="allProjects"
-        label="Select projects"
-        multiple
-      >
-      </v-combobox>
+      <ProjectFilter />
     </td>
     <td>
-      <v-combobox
-        v-model="typesSelected"
-        :items="allTypes"
-        label="Select types"
-        multiple
-      >
-      </v-combobox>
+      <TypeFilter />
+    </td>
+    <td class="pb-5">
+      <DescriptionFilter />
     </td>
     <td>
-      <v-text-field
-        v-model="descriptionSearchText"
-        append-icon="mdi-magnify"
-        label="Search descriptions"
-        single-line
-      ></v-text-field>
+      <CostFilter />
     </td>
     <td>
-      <v-combobox
-        v-model="costCategoriesSelected"
-        :items="allCostCategories"
-        label="Savings/Costs"
-        multiple
-      >
-      </v-combobox>
-    </td>
-    <td>
-      <v-combobox
-        v-model="statusesSelected"
-        :items="allStatuses"
-        label="Select status"
-        multiple
-      >
-      </v-combobox>
+      <StatusFilter />
     </td>
   </tr>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
-import { IRootStoreState } from "../store/root";
-import { costCategoriesNames } from "../store/core_table";
+import CostFilter from "./filters/CostFilter.vue";
+import DescriptionFilter from "./filters/DescriptionFilter.vue";
+import ProjectFilter from "./filters/ProjectFilter.vue";
+import ResourceFilter from "./filters/ResourceFilter.vue";
+import StatusFilter from "./filters/StatusFilter.vue";
+import TypeFilter from "./filters/TypeFilter.vue";
 
-@Component
-export default class FiltersRow extends Vue {
-  // resource name
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
 
-  get resourceNameSearchText(): string {
-    return (this.$store.state as IRootStoreState).coreTableStore!
-      .resourceNameSearchText;
+const FiltersRowProps = Vue.extend({
+  props: {
+    isMobile: {
+      type: Boolean,
+      required: true
+    }
   }
+});
 
-  set resourceNameSearchText(text: string) {
-    this.$store.commit("coreTableStore/setResourceNameSearchText", text);
+@Component({
+  components: {
+    CostFilter,
+    DescriptionFilter,
+    ProjectFilter,
+    ResourceFilter,
+    StatusFilter,
+    TypeFilter
   }
-
-  // description
-
-  get descriptionSearchText(): string {
-    return (this.$store.state as IRootStoreState).coreTableStore!
-      .descriptionSearchText;
-  }
-
-  set descriptionSearchText(text: string) {
-    this.$store.commit("coreTableStore/setDescriptionSearchText", text);
-  }
-
-  // projects
-
-  get allProjects(): string[] {
-    // We could cache these, but filtering is the bottleneck so there is no point to bother
-    return this.$store.getters["recommendationsStore/allProjects"];
-  }
-
-  get projectsSelected(): string[] {
-    return (this.$store.state as IRootStoreState).coreTableStore!
-      .projectsSelected;
-  }
-
-  set projectsSelected(projects: string[]) {
-    this.$store.commit("coreTableStore/setProjectsSelected", projects);
-  }
-
-  // types
-
-  get allTypes(): string[] {
-    return this.$store.getters["recommendationsStore/allTypes"];
-  }
-
-  get typesSelected(): string[] {
-    return (this.$store.state as IRootStoreState).coreTableStore!.typesSelected;
-  }
-
-  set typesSelected(types: string[]) {
-    this.$store.commit("coreTableStore/setTypesSelected", types);
-  }
-
-  // statuses
-
-  get allStatuses(): string[] {
-    return this.$store.getters["recommendationsStore/allStatuses"];
-  }
-
-  get statusesSelected(): string[] {
-    return (this.$store.state as IRootStoreState).coreTableStore!
-      .statusesSelected;
-  }
-
-  set statusesSelected(statuses: string[]) {
-    this.$store.commit("coreTableStore/setStatusesSelected", statuses);
-  }
-
-  // costs
-
-  get allCostCategories(): string[] {
-    return Object.values(costCategoriesNames);
-  }
-
-  get costCategoriesSelected(): string[] {
-    return (this.$store.state as IRootStoreState).coreTableStore!
-      .costCategoriesSelected;
-  }
-  set costCategoriesSelected(costCategories: string[]) {
-    this.$store.commit(
-      "coreTableStore/setCostCategoriesSelected",
-      costCategories
-    );
-  }
-}
+})
+export default class FiltersRow extends FiltersRowProps {}
 </script>

--- a/frontend/src/components/filters/CostFilter.vue
+++ b/frontend/src/components/filters/CostFilter.vue
@@ -1,0 +1,46 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-combobox
+    v-model="costCategoriesSelected"
+    :items="allCostCategories"
+    label="Savings/Costs"
+    multiple
+  >
+  </v-combobox>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { IRootStoreState } from "../../store/root";
+import { costCategoriesNames } from "../../store/core_table";
+
+@Component
+export default class CostFilter extends Vue {
+  get allCostCategories(): string[] {
+    return Object.values(costCategoriesNames);
+  }
+
+  get costCategoriesSelected(): string[] {
+    return (this.$store.state as IRootStoreState).coreTableStore!
+      .costCategoriesSelected;
+  }
+  set costCategoriesSelected(costCategories: string[]) {
+    this.$store.commit(
+      "coreTableStore/setCostCategoriesSelected",
+      costCategories
+    );
+  }
+}
+</script>

--- a/frontend/src/components/filters/DescriptionFilter.vue
+++ b/frontend/src/components/filters/DescriptionFilter.vue
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-text-field
+    v-model="descriptionSearchText"
+    append-icon="mdi-magnify"
+    label="Filter descriptions"
+    single-line
+    hide-details
+  />
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { IRootStoreState } from "../../store/root";
+
+@Component
+export default class DescriptionFilter extends Vue {
+  get descriptionSearchText(): string {
+    return (this.$store.state as IRootStoreState).coreTableStore!
+      .descriptionSearchText;
+  }
+
+  set descriptionSearchText(text: string) {
+    this.$store.commit("coreTableStore/setDescriptionSearchText", text);
+  }
+}
+</script>

--- a/frontend/src/components/filters/ProjectFilter.vue
+++ b/frontend/src/components/filters/ProjectFilter.vue
@@ -1,0 +1,43 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-combobox
+    v-model="projectsSelected"
+    :items="allProjects"
+    label="Select projects"
+    multiple
+  />
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { IRootStoreState } from "../../store/root";
+
+@Component
+export default class ProjectFilter extends Vue {
+  get allProjects(): string[] {
+    // We could cache these, but filtering is the bottleneck so there is no point to bother
+    return this.$store.getters["recommendationsStore/allProjects"];
+  }
+
+  get projectsSelected(): string[] {
+    return (this.$store.state as IRootStoreState).coreTableStore!
+      .projectsSelected;
+  }
+
+  set projectsSelected(projects: string[]) {
+    this.$store.commit("coreTableStore/setProjectsSelected", projects);
+  }
+}
+</script>

--- a/frontend/src/components/filters/ResourceFilter.vue
+++ b/frontend/src/components/filters/ResourceFilter.vue
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-text-field
+    v-model="resourceNameSearchText"
+    append-icon="mdi-magnify"
+    label="Filter resources"
+    single-line
+    hide-details
+  />
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { IRootStoreState } from "../../store/root";
+
+@Component
+export default class ResourceFilter extends Vue {
+  get resourceNameSearchText(): string {
+    return (this.$store.state as IRootStoreState).coreTableStore!
+      .resourceNameSearchText;
+  }
+
+  set resourceNameSearchText(text: string) {
+    this.$store.commit("coreTableStore/setResourceNameSearchText", text);
+  }
+}
+</script>

--- a/frontend/src/components/filters/StatusFilter.vue
+++ b/frontend/src/components/filters/StatusFilter.vue
@@ -1,0 +1,43 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-combobox
+    v-model="statusesSelected"
+    :items="allStatuses"
+    label="Select status"
+    multiple
+  >
+  </v-combobox>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { IRootStoreState } from "../../store/root";
+
+@Component
+export default class StatusFilter extends Vue {
+  get statusesSelected(): string[] {
+    return (this.$store.state as IRootStoreState).coreTableStore!
+      .statusesSelected;
+  }
+
+  set statusesSelected(statuses: string[]) {
+    this.$store.commit("coreTableStore/setStatusesSelected", statuses);
+  }
+
+  get allStatuses(): string[] {
+    return this.$store.getters["recommendationsStore/allStatuses"];
+  }
+}
+</script>

--- a/frontend/src/components/filters/TypeFilter.vue
+++ b/frontend/src/components/filters/TypeFilter.vue
@@ -1,0 +1,42 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-combobox
+    v-model="typesSelected"
+    :items="allTypes"
+    label="Select types"
+    multiple
+  >
+  </v-combobox>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { IRootStoreState } from "../../store/root";
+
+@Component
+export default class ResourceFilter extends Vue {
+  get allTypes(): string[] {
+    return this.$store.getters["recommendationsStore/allTypes"];
+  }
+
+  get typesSelected(): string[] {
+    return (this.$store.state as IRootStoreState).coreTableStore!.typesSelected;
+  }
+
+  set typesSelected(types: string[]) {
+    this.$store.commit("coreTableStore/setTypesSelected", types);
+  }
+}
+</script>


### PR DESCRIPTION
- Components have been separated, so that they can be reused ( Closes: #106 ) :
   - The filters form a full row in desktop mode and occupy just the first column in the mobile mode.
- I also changed "search descriptions" and "search resources" to "filter descriptions" and "filter resources" respectively, so this closes: #83 

Temporarily, it is possible to access these changes even on your phones at [s17k.github.io](https://s17k.github.io).
**After:**
<img src="https://user-images.githubusercontent.com/7630347/90519834-78eb0680-e160-11ea-92f4-0dda98a61e6e.png" width="300">
<img src="https://user-images.githubusercontent.com/7630347/90519806-6cff4480-e160-11ea-989e-fa482d71e48e.png" width="300">


