### PR TITLE
Waiting for googleService requests to finish

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/gin-gonic/gin v1.6.3
+	github.com/google/uuid v1.1.1
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/segmentio/ksuid v1.0.3
 	github.com/stretchr/objx v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/automation/disks.go
+++ b/pkg/automation/disks.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -92,7 +93,10 @@ func (s *googleService) CreateSnapshot(project, zone, disk, name string) error {
 	}
 	disksService := compute.NewDisksService(s.computeService)
 	snapshot := &compute.Snapshot{Name: name}
-	_, err := disksService.CreateSnapshot(project, zone, disk, snapshot).Do()
+	requestID := uuid.New().String()
+	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+		return disksService.CreateSnapshot(project, zone, disk, snapshot).RequestId(requestID).Do()
+	})
 	return err
 }
 
@@ -100,6 +104,9 @@ func (s *googleService) CreateSnapshot(project, zone, disk, name string) error {
 // Requires compute.disks.delete permission.
 func (s *googleService) DeleteDisk(project, zone, disk string) error {
 	disksService := compute.NewDisksService(s.computeService)
-	_, err := disksService.Delete(project, zone, disk).Do()
+	requestID := uuid.New().String()
+	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+		return disksService.Delete(project, zone, disk).RequestId(requestID).Do()
+	})
 	return err
 }

--- a/pkg/automation/disks.go
+++ b/pkg/automation/disks.go
@@ -94,7 +94,7 @@ func (s *googleService) CreateSnapshot(project, zone, disk, name string) error {
 	disksService := compute.NewDisksService(s.computeService)
 	snapshot := &compute.Snapshot{Name: name}
 	requestID := uuid.New().String()
-	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+	err := AwaitCompletion(func() (*compute.Operation, error) {
 		return disksService.CreateSnapshot(project, zone, disk, snapshot).RequestId(requestID).Do()
 	})
 	return err
@@ -105,7 +105,7 @@ func (s *googleService) CreateSnapshot(project, zone, disk, name string) error {
 func (s *googleService) DeleteDisk(project, zone, disk string) error {
 	disksService := compute.NewDisksService(s.computeService)
 	requestID := uuid.New().String()
-	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+	err := AwaitCompletion(func() (*compute.Operation, error) {
 		return disksService.Delete(project, zone, disk).RequestId(requestID).Do()
 	})
 	return err

--- a/pkg/automation/instances.go
+++ b/pkg/automation/instances.go
@@ -19,6 +19,7 @@ package automation
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -27,7 +28,11 @@ func (s *googleService) ChangeMachineType(project string, zone string, instance 
 	machineType = fmt.Sprintf("zones/%s/machineTypes/%s", zone, machineType)
 	request := &compute.InstancesSetMachineTypeRequest{MachineType: machineType}
 	instancesService := compute.NewInstancesService(s.computeService)
-	_, err := instancesService.SetMachineType(project, zone, instance, request).Do()
+
+	requestID := uuid.New().String()
+	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+		return instancesService.SetMachineType(project, zone, instance, request).RequestId(requestID).Do()
+	})
 	return err
 }
 
@@ -40,6 +45,9 @@ func (s *googleService) GetInstance(project string, zone string, instance string
 // StopInstance stops instance using instances.stop method
 func (s *googleService) StopInstance(project string, zone string, instance string) error {
 	instancesService := compute.NewInstancesService(s.computeService)
-	_, err := instancesService.Stop(project, zone, instance).Do()
+	requestID := uuid.New().String()
+	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+		return instancesService.Stop(project, zone, instance).RequestId(requestID).Do()
+	})
 	return err
 }

--- a/pkg/automation/instances.go
+++ b/pkg/automation/instances.go
@@ -30,7 +30,7 @@ func (s *googleService) ChangeMachineType(project string, zone string, instance 
 	instancesService := compute.NewInstancesService(s.computeService)
 
 	requestID := uuid.New().String()
-	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+	err := AwaitCompletion(func() (*compute.Operation, error) {
 		return instancesService.SetMachineType(project, zone, instance, request).RequestId(requestID).Do()
 	})
 	return err
@@ -46,7 +46,7 @@ func (s *googleService) GetInstance(project string, zone string, instance string
 func (s *googleService) StopInstance(project string, zone string, instance string) error {
 	instancesService := compute.NewInstancesService(s.computeService)
 	requestID := uuid.New().String()
-	err := AwaitUntilCompletion(func() (*compute.Operation, error) {
+	err := AwaitCompletion(func() (*compute.Operation, error) {
 		return instancesService.Stop(project, zone, instance).RequestId(requestID).Do()
 	})
 	return err

--- a/pkg/automation/service.go
+++ b/pkg/automation/service.go
@@ -106,13 +106,13 @@ func NewGoogleService(ctx context.Context, conf *oauth2.Config, tok *oauth2.Toke
 	}, nil
 }
 
-// for anonymous functions passed to AwaitUntilCompletion
+// for anonymous functions passed to AwaitCompletion
 type operationGenerator func() (*compute.Operation, error)
 
-// AwaitUntilCompletion takes a function that needs to be called repeatedly
+// AwaitCompletion takes a function that needs to be called repeatedly
 //  to check if a process (some Google Service request) has finished.
 // Such a function is usually constructed by wrapping a .Do() call
-func AwaitUntilCompletion(gen operationGenerator) error {
+func AwaitCompletion(gen operationGenerator) error {
 	for {
 		oper, err := gen()
 		if err != nil {

--- a/pkg/automation/service.go
+++ b/pkg/automation/service.go
@@ -18,6 +18,7 @@ package automation
 
 import (
 	"context"
+	"time"
 
 	"golang.org/x/oauth2"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -103,4 +104,23 @@ func NewGoogleService(ctx context.Context, conf *oauth2.Config, tok *oauth2.Toke
 		resourceManagerService: resourceManagerService,
 		serviceUsageService:    serviceUsageService,
 	}, nil
+}
+
+// for anonymous functions passed to AwaitUntilCompletion
+type operationGenerator func() (*compute.Operation, error)
+
+// AwaitUntilCompletion takes a function that needs to be called repeatedly
+//  to check if a process (some Google Service request) has finished.
+// Such a function is usually constructed by wrapping a .Do() call
+func AwaitUntilCompletion(gen operationGenerator) error {
+	for {
+		oper, err := gen()
+		if err != nil {
+			return err
+		}
+		if oper.Status == "DONE" {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
 }

--- a/pkg/automation/service.go
+++ b/pkg/automation/service.go
@@ -110,8 +110,8 @@ func NewGoogleService(ctx context.Context, conf *oauth2.Config, tok *oauth2.Toke
 type operationGenerator func() (*compute.Operation, error)
 
 // AwaitCompletion takes a function that needs to be called repeatedly
-//  to check if a process (some Google Service request) has finished.
-// Such a function is usually constructed by wrapping a .Do() call
+// to check if a process (some Google Service request) has finished.
+// Such a function is usually constructed by wrapping a requestId(x).Do() call.
 func AwaitCompletion(gen operationGenerator) error {
 	for {
 		oper, err := gen()

--- a/pkg/automation/service_test.go
+++ b/pkg/automation/service_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package automation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+)
+
+func TestAwaitCompletion(t *testing.T) {
+	// fast failure
+	err := AwaitCompletion(fastFailingOperationGen)
+	assert.EqualError(t, err, "Oh no")
+
+	//ending in success
+	longOperationGenCounter = 0
+	longOperationGenShouldSucceed = true
+	err = AwaitCompletion(longOperationGen)
+	assert.Nil(t, err)
+	assert.Equal(t, longOperationGenCounter, 3)
+
+	//ending in failure
+	longOperationGenCounter = 0
+	longOperationGenShouldSucceed = false
+	err = AwaitCompletion(longOperationGen)
+	assert.EqualError(t, err, "Oh no")
+	assert.Equal(t, longOperationGenCounter, 3)
+}
+
+func fastFailingOperationGen() (*compute.Operation, error) {
+	return nil, errors.New("Oh no")
+}
+
+var longOperationGenCounter int
+var longOperationGenShouldSucceed bool
+
+func longOperationGen() (*compute.Operation, error) {
+	longOperationGenCounter++
+	switch longOperationGenCounter {
+	case 1, 2:
+		return &compute.Operation{Status: "PROCESSING"}, nil
+	case 3:
+		if longOperationGenShouldSucceed {
+			return &compute.Operation{Status: "DONE"}, nil
+		}
+		return &compute.Operation{Status: "Done"}, errors.New("Oh no")
+	default:
+		panic("too many calls")
+	}
+}


### PR DESCRIPTION
- Added waiting for non-get requests to finish before returning.

~~I will add tests once this is pre-approved, as agreed.~~
Maybe it's not too useful to actually make tests for these, as they would need to be very tightly coupled with the implementation.

As of now, these have been tested and work (verified on Pantheon individually)
- `CreateSnapshot` 
- `StopInstance`
- `DeleteDisk`
- `ChangeMachineType`