### PR TITLE
Frontend - more flexible fetch & better handling of status updates

### DIFF
--- a/frontend/src/components/ApplyAndStatusCell.vue
+++ b/frontend/src/components/ApplyAndStatusCell.vue
@@ -40,12 +40,16 @@ limitations under the License. -->
     </v-btn>
 
     <!-- Error dialog (with the 'Failed' button defined inside) -->
-    <v-dialog
-      v-model="errorDialogOpened"
-      max-width="600px"
-    >
+    <v-dialog v-model="errorDialogOpened" max-width="600px">
       <template v-slot:activator="{ on }">
-        <v-btn v-show="checkStatus('FAILED')" color="red darken-2" v-on="on" small rounded block>
+        <v-btn
+          v-show="checkStatus('FAILED')"
+          color="red darken-2"
+          v-on="on"
+          small
+          rounded
+          block
+        >
           <v-icon left color="white">mdi-alert-box</v-icon>
           Show Error
         </v-btn>

--- a/frontend/src/components/ApplyAndStatusCell.vue
+++ b/frontend/src/components/ApplyAndStatusCell.vue
@@ -17,7 +17,7 @@ limitations under the License. -->
     <v-btn
       rounded
       color="primary"
-      v-if="checkStatus('ACTIVE') || checkStatus('CLAIMED')"
+      v-show="checkStatus('ACTIVE') || checkStatus('CLAIMED')"
       v-on:click="applyRecommendation()"
       :loading="checkStatus('CLAIMED')"
       dark
@@ -31,7 +31,7 @@ limitations under the License. -->
       rounded
       small
       label
-      v-if="checkStatus('SUCCEEDED')"
+      v-show="checkStatus('SUCCEEDED')"
       color="green"
       block
     >
@@ -39,14 +39,13 @@ limitations under the License. -->
       {{ rowRecommendation.statusCol }}
     </v-btn>
 
-    <!-- Error dialog -->
+    <!-- Error dialog (with the 'Failed' button defined inside) -->
     <v-dialog
-      v-if="checkStatus('FAILED')"
       v-model="errorDialogOpened"
       max-width="600px"
     >
       <template v-slot:activator="{ on }">
-        <v-btn color="red darken-2" v-on="on" small rounded block>
+        <v-btn v-show="checkStatus('FAILED')" color="red darken-2" v-on="on" small rounded block>
           <v-icon left color="white">mdi-alert-box</v-icon>
           Show Error
         </v-btn>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -58,8 +58,8 @@ limitations under the License. -->
           <v-btn
             color="green white--text"
             v-on:click="
-              applySelectedRecommendations();
               dialog = false;
+              applySelectedRecommendations();
             "
           >
             <v-icon>mdi-check</v-icon>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -27,6 +27,8 @@ errors disappear, make sure that Go is in the latest version too. */
 
 // Asynchronously request and receive recommendations from the middleware
 store.dispatch("recommendationsStore/fetchRecommendations");
+// Start status watchers
+store.dispatch("recommendationsStore/watchStatusForAll");
 
 new Vue({
   router,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -28,7 +28,7 @@ errors disappear, make sure that Go is in the latest version too. */
 // Asynchronously request and receive recommendations from the middleware
 store.dispatch("recommendationsStore/fetchRecommendations");
 // Start status watchers
-store.dispatch("recommendationsStore/watchStatusForAll");
+store.dispatch("recommendationsStore/startCentralStatusWatcher");
 
 new Vue({
   router,

--- a/frontend/src/store/data_model/recommendation_extra.ts
+++ b/frontend/src/store/data_model/recommendation_extra.ts
@@ -46,6 +46,9 @@ export class RecommendationExtra implements RecommendationRaw {
   errorHeader?: string; // if apply fails,
   errorDescription?: string; // error details are stored here
 
+  // decides if checkStatus requests are sent once in a while
+  needsStatusWatcher = false;
+
   constructor(rec: RecommendationRaw) {
     this.name = rec.name;
     this.description = rec.description;

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -294,18 +294,20 @@ interface ICheckStatusResponse {
 }
 
 const getters: GetterTree<IRecommendationsStoreState, IRootStoreState> = {
-  // Used for calculating filter choices
+  // Used for calculating filter choices, sorted to avoid changes in order 
+  // caused by a different set of recommendations in a filtered view
+  // (for example. the first type found might change very frequently) 
 
   allProjects(state): string[] {
-    const projects = state.recommendations.map(r => r.projectCol);
+    const projects = state.recommendations.map(r => r.projectCol).sort();
     return Array.from(new Set(projects));
   },
   allTypes(state): string[] {
-    const types = state.recommendations.map(r => r.typeCol);
+    const types = state.recommendations.map(r => r.typeCol).sort();
     return Array.from(new Set(types));
   },
   allStatuses(state): string[] {
-    const statuses = state.recommendations.map(r => r.statusCol);
+    const statuses = state.recommendations.map(r => r.statusCol).sort();
     return Array.from(new Set(statuses));
   }
 };

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -88,21 +88,22 @@ const mutations: MutationTree<IRecommendationsStoreState> = {
 
 const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
   // Makes requests to the middleware and adds obtained recommendations to the store
+  // - it can only be run once in the app lifetime,
+  //    as there is no way to stop status watchers atm
   async fetchRecommendations(context): Promise<void> {
+    // one fetch at a time only
     if (context.state.progress !== null) {
       return;
     }
-
+    context.commit("resetRecommendations");
     context.commit("setProgress", 0);
 
-    let response;
-    let responseJson;
-    let responseCode;
-
+    // send /recommendations requests until data received
+    let responseJson: any;
     for (;;) {
-      response = await fetch(`${SERVER_ADDRESS}/recommendations`);
+      const response = await fetch(`${SERVER_ADDRESS}/recommendations`);
       responseJson = await response.json();
-      responseCode = response.status;
+      const responseCode = response.status;
 
       if (responseCode !== HTTP_OK_CODE) {
         context.commit("setError", {

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -277,9 +277,12 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
         recName: rec.name,
         newStatus: "FAILED"
       });
-      rec.errorHeader = `Status query failed (HTTP:${response.status})`;
-      rec.errorDescription =
-        "Failed to reach the Recomator API, recommendation status is unknown. We will try again in a moment.";
+      commit("setRecommendationError", {
+        recName: rec.name,
+        header: `Status query failed (HTTP:${response.status})`,
+        desc:
+          "Failed to reach the Recomator API, recommendation status is unknown. We will try again in a moment."
+      });
     }
     return true; // Continue watching the status, maybe this is a temporary connection error
   }

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -221,7 +221,7 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
       await delay(APPLY_PROGRESS_WAIT_TIME);
     }
   },
-  // Should return nearly immediately,
+  // Should return nearly immediately. Assumes the recommendation was applied by us (not Pantheon, for example)
   // the promise encapsulates the answer to: do we want to continue watching this recommendation?
   async watchStatusOnce(
     { commit },
@@ -251,7 +251,7 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
           });
           return false;
 
-        // Now we know it failed, tell the user why and return: false
+        // Now we know it failed, save the error message and tell the user why
 
         case "NOT APPLIED":
           commit("setRecommendationStatus", {

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -98,8 +98,6 @@ const mutations: MutationTree<IRecommendationsStoreState> = {
 
 const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
   // Makes requests to the middleware and adds obtained recommendations to the store
-  // - it can only be run once in the app lifetime,
-  //    as there is no way to stop status watchers atm
   async fetchRecommendations(context): Promise<void> {
     // one fetch at a time only
     if (context.state.progress !== null) {
@@ -162,7 +160,7 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
     if (selectedRecs.includes(undefined))
       throw "Name given doesn't match an existing recommendation";
 
-    // Apply all, waiting for them to send
+    // Apply all, waiting for them to send one by one
     for (const rec of selectedRecs)
       await dispatch("applySingleRecommendation", rec);
   },

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -188,6 +188,10 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
         needs: true
       });
     else {
+      commit("setRecommendationNeedsStatusWatcher", {
+        recName: rec.name,
+        needs: false
+      });
       commit("setRecommendationStatus", {
         recName: rec.name,
         newStatus: "FAILED"

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -124,11 +124,11 @@ describe("applySingleRecommendation action", () => {
   });
 });
 
-describe("watchStatusOnce action", () => {
-  let watchStatusOnce: any;
+describe("checkStatusOnce action", () => {
+  let checkStatusOnce: any;
   beforeAll(() => {
-    watchStatusOnce = recommendationStoreFactory().actions![
-      "watchStatusOnce"
+    checkStatusOnce = recommendationStoreFactory().actions![
+      "checkStatusOnce"
     ] as any;
   });
   beforeEach(() => {
@@ -137,7 +137,7 @@ describe("watchStatusOnce action", () => {
 
   test("-> in progress", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ status: "IN PROGRESS" }));
-    const shouldContinue = await watchStatusOnce(context, firstRec);
+    const shouldContinue = await checkStatusOnce(context, firstRec);
 
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("CLAIMED"));
     expect(shouldContinue).toBeTruthy();
@@ -145,7 +145,7 @@ describe("watchStatusOnce action", () => {
 
   test("-> succeeded", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ status: "SUCCEEDED" }));
-    const shouldContinue = await watchStatusOnce(context, firstRec);
+    const shouldContinue = await checkStatusOnce(context, firstRec);
 
     expect((fetch as any).mock.calls[0][0].indexOf(firstRec.name)).not.toBe(-1);
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("SUCCEEDED"));
@@ -154,7 +154,7 @@ describe("watchStatusOnce action", () => {
 
   test("-> not applied", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ status: "NOT APPLIED" }));
-    const shouldContinue = await watchStatusOnce(context, firstRec);
+    const shouldContinue = await checkStatusOnce(context, firstRec);
 
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
     expect(firstRec.errorHeader!.startsWith("Server has")).toBeTruthy();
@@ -168,7 +168,7 @@ describe("watchStatusOnce action", () => {
         errorMessage: "something bad happened"
       })
     );
-    const shouldContinue = await watchStatusOnce(context, firstRec);
+    const shouldContinue = await checkStatusOnce(context, firstRec);
 
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
     expect(firstRec.errorHeader!.startsWith("Applying ")).toBeTruthy();
@@ -178,7 +178,7 @@ describe("watchStatusOnce action", () => {
 
   test("-> gibberish", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ status: "%%%" }));
-    const shouldContinue = await watchStatusOnce(context, firstRec);
+    const shouldContinue = await checkStatusOnce(context, firstRec);
 
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
     expect(firstRec.errorHeader!.startsWith("Bad status(")).toBeTruthy();
@@ -189,7 +189,7 @@ describe("watchStatusOnce action", () => {
     fetchMock.mockResponseOnce(async () => {
       return { status: 404, body: "Endpoint not found" };
     });
-    const shouldContinue = await watchStatusOnce(context, firstRec);
+    const shouldContinue = await checkStatusOnce(context, firstRec);
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));
     expect(firstRec.errorHeader?.indexOf("404")).not.toBe(-1);
     expect(shouldContinue).toBeTruthy(); // try again in this case

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -111,7 +111,7 @@ describe("applySingleRecommendation action", () => {
 
     expect((fetch as any).mock.calls.length).toEqual(1);
     expect((fetch as any).mock.calls[0][0].indexOf(firstRec.name)).not.toBe(-1);
-    expect(dispatch.mock.calls).toEqual([["watchStatus", firstRec]]);
+    expect(firstRec.needsStatusWatcher).toBeTruthy();
     expect(firstRec.statusCol).toEqual(getInternalStatusMapping("CLAIMED"));
   });
 
@@ -122,7 +122,7 @@ describe("applySingleRecommendation action", () => {
     await applier(context, firstRec);
 
     expect((fetch as any).mock.calls.length).toEqual(1);
-    expect(dispatch).toHaveBeenCalledTimes(0);
+    expect(firstRec.needsStatusWatcher).toBeFalsy();
     expect(firstRec.statusCol).toEqual(getInternalStatusMapping("FAILED"));
     expect(firstRec.errorHeader).not.toBeNull();
   });

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -66,29 +66,25 @@ afterEach(() => {
   dispatch.mockClear();
 });
 
-test("applyGivenRecommendations action", () => {
+test("applyGivenRecommendations action", async () => {
   const applier = recommendationStoreFactory().actions![
     "applyGivenRecommendations"
   ] as any;
-  expect(applier).not.toBeNull();
+
+  // Note: rejects/resolves fails (good) if the Promise actually doesn't
 
   // duplicates
-  expect(() => {
-    applier(context, ["a/b", "a/b"]);
-  }).toThrowError();
+  await expect(applier(context, ["a/b", "a/b"])).rejects.not.toBeNull();
   expect(dispatch).toBeCalledTimes(0);
 
   // non-existent
   dispatch.mockReset();
-  expect(() => {
-    applier(context, ["a/b", "a/b/c/d"]);
-  }).toThrowError();
+  await expect(applier(context, ["a/b", "a/b/c/d"])).rejects.not.toBeNull();
   expect(dispatch).toBeCalledTimes(0);
 
+  // succeeding
   dispatch.mockReset();
-  expect(() => {
-    applier(context, ["a/b/c", "a/b"]);
-  }).not.toThrowError();
+  await expect(applier(context, ["a/b/c", "a/b"])).resolves.not.toBeNull();
   expect(dispatch).toBeCalledTimes(2);
   expect(dispatch.mock.calls[0][0]).toBe("applySingleRecommendation");
   expect(dispatch.mock.calls[1][0]).toBe("applySingleRecommendation");


### PR DESCRIPTION
- Existing recommendations are removed at the beginning of a fetch now (so that if we have authorization errors, we can easily and safely restart it):  https://github.com/googleinterns/recomator/pull/129/commits/106045e7fa1e10fe237403633e72a71808ae6c44
- We now track recommendations which need to have their status watched with a new field in `RecommendationExtra` called `needsStatusWatcher`. This allows us to just iterate through all recommendations in the watchStatus infinite loop, and easily handle the recommendations list changing. 

Requests (/apply, /watchStatus) are now sent sequentially (waiting asynchronously for the previous one to finish before sending a new one). What used to be done was sending all the requests one after another, then asynchronously handling all their responses. This used to cause the UI to halt for a few seconds and update much slower (most probably because there was a large chunk of work that stayed at the top of the event queue for these few seconds).
 https://github.com/googleinterns/recomator/pull/129/commits/b085b2a88fc67688b1048b8d5fc62d9622ba0234 
https://github.com/googleinterns/recomator/pull/129/commits/d9263c385ffd3bdf97b111ef26b07e7ed467fbc4 (second commit ammends the first one so that requests are done sequentially, as described above) 
https://github.com/googleinterns/recomator/pull/129/commits/54ff19f2150b440ea2d50407b1830d051af87c91 (made a function out of the core of `centralStatusWatcher`) 
https://github.com/googleinterns/recomator/pull/129/commits/3e2821e6173b46e2acf7f94e03a44f3c093b48bc (tests)

  - recommendations that were `CLAIMED` when we got them are no longer watched (at least for now, added this as an issue: https://github.com/googleinterns/recomator/issues/131), as this makes it complex to distinguish between getting `NOT APPLIED` from `checkStatus` because:
     - the backend hasn't acknowledged the `apply` request that the frontend has sent
     - the recommendation was applied earlier and is still `CLAIMED`, for example by Pantheon or an API or even the same Recomator backend instance but in a different fetch
```typescript
async startCentralStatusWatcher({ commit, dispatch }): Promise<void> {
    commit("registerCentralStatusWatcher");
    for (;;) {
      await dispatch("checkStatusOnceForAll");
      // ask the browser to do something else for a bit and then resume
      await delay(APPLY_PROGRESS_WAIT_TIME);
    }
 }
async checkStatusOnceForAll({ state, commit, dispatch }): Promise<void> {
    // make a copy first to make the array constant inside the for loop
    const recsCopy = state.recommendations.map(rec => rec);

    // check status of all recommendations that need to be watched
    // (waits for a response before starting a new request)
    for (const rec of recsCopy) {
      if (!rec.needsStatusWatcher) continue;

      const shouldContinue = await dispatch("checkStatusOnce", rec);
      commit("setRecommendationNeedsStatusWatcher", {
        recName: rec.name,
        needs: shouldContinue
      });
    }
 }
```
- Fix: status was changed directly, not through a mutation https://github.com/googleinterns/recomator/pull/129/commits/2b56fa2ea37b0352f25ddb16f7b3b41617a7fb73
- Fix: status filter options were changing very frequently (more than once per second) when statuses were updated https://github.com/googleinterns/recomator/pull/129/commits/5bfa97aca4de90578f311fa2b01586a895b68282
- Performance fix: changing `v-if` to `v-show` improved rendering performance significantly (from what I observed visually), as I observed that icons render for the longest time (Vue extension shows these stats) so it is better not to re-render them each time status changes (`v-if`'s behaviour). https://github.com/googleinterns/recomator/pull/129/commits/02d79f923a9407c15a05e2da8d9e1cfc0278ff47
