### PR TITLE
Footer upgrade

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -17,24 +17,26 @@ limitations under the License. -->
     <v-footer
       v-if="selectedRowsCount > 0"
       v-bind:fixed="true"
-      color="rgba(255, 210, 20, 1)"
-      class="pa-xl-6 pa-lg-5 pa-md-4 pa-sm-3 pa-xs-0 justify-center"
+      color="primary"
       v-bind:app="true"
     >
-      <v-container>
-        <v-row>
-          <v-col :cols="12" :lg="8">
-            <div class="font-weight-black">
-              {{ footerMessage }}
-            </div>
-          </v-col>
-          <v-col :cols="12" :lg="4">
-            <v-btn rounded color="primary" dark v-on:click="dialog = true"
-              >Apply Selected Recommendation{{
-                selectedRowsCount == 1 ? "" : "s"
-              }}</v-btn
+      <v-container fluid>
+        <v-row align="center" justify="space-around" justify-md="space-between">
+              <v-btn fab small dark color="secondary" v-on:click="unselectAll">
+                  <v-icon dark>mdi-close</v-icon>
+              </v-btn>
+          <div>
+              <div style="font-weight: bold; color: white">
+            {{applyPart}}<br/>
+            <span v-if="spendingsPart.length>0">{{spendingsPart}}<br/></span>
+            <span v-if="savingsPart.length>0">{{savingsPart}}</span>
+              </div>
+          </div>
+          <div>
+            <v-btn rounded color="secondary" style="font-weight: bold" dark v-on:click="dialog = true"
+              >Apply Selected</v-btn
             >
-          </v-col>
+          </div>
         </v-row>
       </v-container>
     </v-footer>
@@ -116,9 +118,7 @@ export default class Footer extends Vue {
   // Footer summary generators:
 
   get applyPart(): string {
-    return `Apply ${this.selectedRowsCount} recommendation${
-      this.selectedRowsCount == 1 ? "" : "s"
-    }.`;
+    return `Apply ${this.selectedRowsCount} recommendation(s):`;
   }
 
   get savingsPart(): string {
@@ -127,9 +127,9 @@ export default class Footer extends Vue {
       return "";
     }
 
-    return ` Save ${savings.toFixed(
+    return `Use less resources and save ${savings.toFixed(
       2
-    )}$ each week by using only the necessary resources.`;
+    )}$ each week.`;
   }
 
   get spendingsPart(): string {
@@ -139,11 +139,7 @@ export default class Footer extends Vue {
 
     return ` Increase performance of ${this.performanceSelectedCount} machine${
       this.performanceSelectedCount == 1 ? "" : "s"
-    }, by spending ${this.spendingsFromSelected.toFixed(2)}$ more each week.`;
-  }
-
-  get footerMessage(): string {
-    return this.applyPart + this.savingsPart + this.spendingsPart;
+    } by spending ${this.spendingsFromSelected.toFixed(2)}$ more each week.`;
   }
 
   // Handler of the 'Apply all selected' button
@@ -152,6 +148,10 @@ export default class Footer extends Vue {
       "recommendationsStore/applyGivenRecommendations",
       this.selectedRows.map(row => row.name)
     );
+    this.unselectAll();
+  }
+
+  unselectAll() : void {
     this.$store.commit("coreTableStore/setSelected", []);
   }
 }

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -22,18 +22,25 @@ limitations under the License. -->
     >
       <v-container fluid>
         <v-row align="center" justify="space-around" justify-md="space-between">
-              <v-btn fab small dark color="secondary" v-on:click="unselectAll">
-                  <v-icon dark>mdi-close</v-icon>
-              </v-btn>
+          <v-btn fab small dark color="secondary" v-on:click="unselectAll">
+            <v-icon dark>mdi-close</v-icon>
+          </v-btn>
           <div>
-              <div style="font-weight: bold; color: white">
-            {{applyPart}}<br/>
-            <span v-if="spendingsPart.length>0">{{spendingsPart}}<br/></span>
-            <span v-if="savingsPart.length>0">{{savingsPart}}</span>
-              </div>
+            <div style="font-weight: bold; color: white">
+              {{ applyPart }}<br />
+              <span v-if="spendingsPart.length > 0"
+                >{{ spendingsPart }}<br
+              /></span>
+              <span v-if="savingsPart.length > 0">{{ savingsPart }}</span>
+            </div>
           </div>
           <div>
-            <v-btn rounded color="secondary" style="font-weight: bold" dark v-on:click="dialog = true"
+            <v-btn
+              rounded
+              color="secondary"
+              style="font-weight: bold"
+              dark
+              v-on:click="dialog = true"
               >Apply Selected</v-btn
             >
           </div>
@@ -127,9 +134,7 @@ export default class Footer extends Vue {
       return "";
     }
 
-    return `Use less resources and save ${savings.toFixed(
-      2
-    )}$ each week.`;
+    return `Use less resources and save ${savings.toFixed(2)}$ each week.`;
   }
 
   get spendingsPart(): string {
@@ -151,7 +156,7 @@ export default class Footer extends Vue {
     this.unselectAll();
   }
 
-  unselectAll() : void {
+  unselectAll(): void {
     this.$store.commit("coreTableStore/setSelected", []);
   }
 }


### PR DESCRIPTION
- adds the 'X' button that @minorczyka suggested to clear selections and hide the footer (closes: #124)
- in my opinon a blue footer looks nicer than a yellow one; that is the primary theme colour and the colour of the header. I am open to suggestions though.
- the UX expert suggested to keep lines below 70 characters, so the summary occupies 2 or 3 lines now (closes: #103)
- simplified the margins/paddings: having too many screen size breakpoints will be hard to maintain 

### Screenshots (before/after, desktop/mobile)
**Desktop before**:
<img src="https://user-images.githubusercontent.com/7630347/91587295-7782c080-e94e-11ea-8e6c-5b932238192e.png" width="800">
**Desktop after**:
<img src="https://user-images.githubusercontent.com/7630347/91588793-9da96000-e950-11ea-8b5f-73f6f298279d.png" width="800">




**Mobile before**:
<img src="https://user-images.githubusercontent.com/7630347/91587173-528e4d80-e94e-11ea-8052-048dde09179d.png" width="300">
**Mobile after**:
<img src="https://user-images.githubusercontent.com/7630347/91589030-fb3dac80-e950-11ea-999d-4c4081ccf0be.png" width="300">


