### PR TITLE
checkStatus endpoint interface update

### DIFF
--- a/frontend/src/store/data_model/recommendation_extra.ts
+++ b/frontend/src/store/data_model/recommendation_extra.ts
@@ -62,5 +62,7 @@ export class RecommendationExtra implements RecommendationRaw {
     this.resourceCol = getRecommendationResourceShortName(rec);
     this.typeCol = getRecommendationType(rec);
     this.statusCol = getInternalStatusMapping(rec.stateInfo.state);
+    this.needsStatusWatcher =
+      this.statusCol === getInternalStatusMapping("CLAIMED");
   }
 }

--- a/frontend/tests/unit/apply.spec.ts
+++ b/frontend/tests/unit/apply.spec.ts
@@ -198,12 +198,15 @@ describe("checkStatusOnce action", () => {
     jest.useFakeTimers(); // mocked setTimeout
   });
 
-  test("-> in progress", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ status: "IN PROGRESS" }));
-    const shouldContinue = await checkStatusOnce(context, firstRec);
+  // applied by us/someone else
+  test("-> in progress/claimed", async () => {
+    for (const status of ["CLAIMED", "IN PROGRESS"]) {
+      fetchMock.mockResponseOnce(JSON.stringify({ status: status }));
+      const shouldContinue = await checkStatusOnce(context, firstRec);
 
-    expect(firstRec.statusCol).toBe(getInternalStatusMapping("CLAIMED"));
-    expect(shouldContinue).toBeTruthy();
+      expect(firstRec.statusCol).toBe(getInternalStatusMapping("CLAIMED"));
+      expect(shouldContinue).toBeTruthy();
+    }
   });
 
   test("-> succeeded", async () => {
@@ -215,8 +218,8 @@ describe("checkStatusOnce action", () => {
     expect(shouldContinue).toBeFalsy();
   });
 
-  test("-> not applied", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ status: "NOT APPLIED" }));
+  test("-> active", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "ACTIVE" }));
     const shouldContinue = await checkStatusOnce(context, firstRec);
 
     expect(firstRec.statusCol).toBe(getInternalStatusMapping("FAILED"));


### PR DESCRIPTION
These are frontend changes needed for the `/checkStatus` endpoint update, as described below. Closes: #131 
The `/checkStatus` endpoint used to return `"NOT APPLIED", "SUCCEEDED", "FAILED" or "IN PROGRESS" `so there was no way  to check status on recommendations applied anywhere outside the app.
This endpoint has been updated and now returns` "CLAIMED"/"IN PROGRESS"/"ACTIVE"/"FAILED"/"SUCCEEDED" `(so it matches the Recommender API status names, and adds `"IN PROGRESS"` to mark recommendations that are in progress **and** have been applied by the Recomator).