### PR TITLE
Status filter options made constant: fixed #140

### DIFF
--- a/frontend/src/components/filters/StatusFilter.vue
+++ b/frontend/src/components/filters/StatusFilter.vue
@@ -14,7 +14,7 @@ limitations under the License. -->
 <template>
   <v-combobox
     v-model="statusesSelected"
-    :items="allStatuses"
+    :items="allInternalStatuses"
     label="Select status"
     multiple
   >
@@ -24,6 +24,7 @@ limitations under the License. -->
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { IRootStoreState } from "../../store/root";
+import { allInternalStatuses } from "../../store/data_model/status_map";
 
 @Component
 export default class StatusFilter extends Vue {
@@ -36,8 +37,8 @@ export default class StatusFilter extends Vue {
     this.$store.commit("coreTableStore/setStatusesSelected", statuses);
   }
 
-  get allStatuses(): string[] {
-    return this.$store.getters["recommendationsStore/allStatuses"];
+  get allInternalStatuses(): string[] {
+    return allInternalStatuses();
   }
 }
 </script>

--- a/frontend/src/components/filters/StatusFilter.vue
+++ b/frontend/src/components/filters/StatusFilter.vue
@@ -37,6 +37,7 @@ export default class StatusFilter extends Vue {
     this.$store.commit("coreTableStore/setStatusesSelected", statuses);
   }
 
+  // fixed list of internal names of statuses
   get allInternalStatuses(): string[] {
     return allInternalStatuses();
   }

--- a/frontend/src/store/data_model/status_map.ts
+++ b/frontend/src/store/data_model/status_map.ts
@@ -31,3 +31,7 @@ export function getInternalStatusMapping(statusName: string): string {
   throwIfInvalidStatus(statusName);
   return internalStatusMap[statusName];
 }
+
+export function allInternalStatuses(): string[] {
+  return Object.values(internalStatusMap);
+}


### PR DESCRIPTION
What I observed was that page size was the factor determining the speed of statuses updates in the UI.

Status filter options are currently dynamically calculated from all observed statuses (possibly thousands of them). That is why, if you open about a 1000 of recommendations and apply all of them, these options will need to be recalculated about 1000 times (possibly millions of operations). This combined with frequent repainting makes it unacceptably slow.

I fixed them to all internal statuses instead, the statuses are now updating at least 2x faster (possibly much more than that) for larger page sizes.