### PR TITLE
No tooltip transition. Fixes: #81

### DIFF
--- a/frontend/src/components/SavingsCostCell.vue
+++ b/frontend/src/components/SavingsCostCell.vue
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. -->
 <template>
   <div>
-    <v-tooltip bottom>
+    <v-tooltip bottom transition="none">
       <template v-slot:activator="{ on, attrs }">
         <v-chip
           :color="costColour"


### PR DESCRIPTION
The solution proposed here is not as straightforward as it may seem. "none" is actually an invalid transition name, it could have been "nope" or "ice cream". What matters is that this removes all transitions, which is what we want.

The [solution](https://github.com/vuetifyjs/vuetify/issues/3453) proposed by a Vuetify contributor assumes the CSS class names (which I couldn't even find for v-tooltip). This confirms that there is probably no clean solution for this and I believe the one I am proposing is actually better because it is much simpler.