### PR TITLE
Frontend resource link

### DIFF
--- a/frontend/src/components/ResourceCell.vue
+++ b/frontend/src/components/ResourceCell.vue
@@ -13,13 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License. -->
 <template>
   <div>
-    {{ shortName }}
+    <a :href="pantheonLink"> {{ shortName }} </a>
   </div>
 </template>
 <script lang="ts">
 import Vue, { PropType } from "vue";
 import { Component } from "vue-property-decorator";
 import { RecommendationExtra } from "../store/data_model/recommendation_extra";
+import { getResourcePantheonLink } from "../store/data_model/recommendation_raw";
 
 const ResourceCellProps = Vue.extend({
   props: {
@@ -34,6 +35,9 @@ const ResourceCellProps = Vue.extend({
 export default class ResourceCell extends ResourceCellProps {
   get shortName() {
     return this.rowRecommendation.resourceCol;
+  }
+  get pantheonLink() {
+    return getResourcePantheonLink(this.rowRecommendation);
   }
 }
 </script>

--- a/frontend/src/components/ResourceCell.vue
+++ b/frontend/src/components/ResourceCell.vue
@@ -13,14 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License. -->
 <template>
   <div>
-    <a :href="pantheonLink"> {{ shortName }} </a>
+    <a :href="consoleLink"> {{ shortName }} </a>
   </div>
 </template>
 <script lang="ts">
 import Vue, { PropType } from "vue";
 import { Component } from "vue-property-decorator";
 import { RecommendationExtra } from "../store/data_model/recommendation_extra";
-import { getResourcePantheonLink } from "../store/data_model/recommendation_raw";
+import { getResourceConsoleLink } from "../store/data_model/recommendation_raw";
 
 const ResourceCellProps = Vue.extend({
   props: {
@@ -36,8 +36,8 @@ export default class ResourceCell extends ResourceCellProps {
   get shortName() {
     return this.rowRecommendation.resourceCol;
   }
-  get pantheonLink() {
-    return getResourcePantheonLink(this.rowRecommendation);
+  get consoleLink() {
+    return getResourceConsoleLink(this.rowRecommendation);
   }
 }
 </script>

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -149,6 +149,7 @@ export function getRecommendationFirstValue(
   return recommendation.content.operationGroups[0].operations[0].value;
 }
 
+// (b, /a/b/c/d/e) => c
 export function extractFromResource(
   property: string,
   resource: string
@@ -159,7 +160,7 @@ export function extractFromResource(
 
   const found = regex.exec(resource);
   if (found === null) {
-    throw `couldn't parse resource identifier: ${resource}`;
+    throw `couldn't parse identifier: ${resource}`;
   }
 
   const result = found[0].slice(sliceLen);

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -155,7 +155,8 @@ export function getRecommendationFirstValue(
   return recommendation.content.operationGroups[0].operations[0].value;
 }
 
-// (b, /a/b/c/d/e) => c
+// Searches for property and returns the part after the next slash
+// For example: (b, /a/b/c/d/e) => c (first occurence of /b/ is followed by c)
 export function extractFromResource(
   property: string,
   resource: string

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+// RecommendationRaw definition and parsers
 // Follows data model from:
 //    https://cloud.google.com/recommender/docs/reference/rest/v1beta1/projects.locations.recommenders.recommendations
 

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -268,16 +268,16 @@ export function getRecommendationZone(recommendation: RecommendationRaw) {
   return extractFromResource("zones", resource);
 }
 
-export function getResourcePantheonLink(recommendation: RecommendationRaw) {
+export function getResourceConsoleLink(recommendation: RecommendationRaw) {
   const zone = getRecommendationZone(recommendation);
   const project = getRecommendationProject(recommendation);
   const shortName = getRecommendationResourceShortName(recommendation);
   const type = getRecommendationType(recommendation);
   switch (type) {
     case "SNAPSHOT_AND_DELETE_DISK": // disks
-      return `https://pantheon.corp.google.com/compute/disksDetail/zones/${zone}/disks/${shortName}?project=${project}`;
+      return `https://console.cloud.google.com/compute/disksDetail/zones/${zone}/disks/${shortName}?project=${project}`;
     default:
       // instances
-      return `https://pantheon.corp.google.com/compute/instancesDetail/zones/${zone}/instances/${shortName}?project=${project}`;
+      return `https://console.cloud.google.com/compute/instancesDetail/zones/${zone}/instances/${shortName}?project=${project}`;
   }
 }

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -159,9 +159,7 @@ export function extractFromResource(
 
   const found = regex.exec(resource);
   if (found === null) {
-    // TODO: this function doesn't support snapshots, so I have temporarily disabled errors
-    return "NOT IMPLEMENTED";
-    //throw `couldn't parse resource identifier: ${resource}`;
+    throw `couldn't parse resource identifier: ${resource}`;
   }
 
   const result = found[0].slice(sliceLen);

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -12,8 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import { extractFromResource } from "../utils/misc";
-
 // Follows data model from:
 //    https://cloud.google.com/recommender/docs/reference/rest/v1beta1/projects.locations.recommenders.recommendations
 
@@ -148,6 +146,25 @@ export function getRecommendationFirstValue(
   recommendation: RecommendationRaw
 ): string | AddOperationValue | undefined {
   return recommendation.content.operationGroups[0].operations[0].value;
+}
+
+export function extractFromResource(
+  property: string,
+  resource: string
+): string {
+  const sliceLen = `/${property}/`.length;
+  const pattern = `/${property}/[^/]*`;
+  const regex = new RegExp(pattern);
+
+  const found = regex.exec(resource);
+  if (found === null) {
+    // TODO: this function doesn't support snapshots, so I have temporarily disabled errors
+    return "NOT IMPLEMENTED";
+    //throw `couldn't parse resource identifier: ${resource}`;
+  }
+
+  const result = found[0].slice(sliceLen);
+  return result;
 }
 
 // Returns a name to identify the related resource by, regardless of recommendation type.

--- a/frontend/src/store/utils/misc.ts
+++ b/frontend/src/store/utils/misc.ts
@@ -14,25 +14,6 @@ limitations under the License. */
 
 import { ProjectConfig } from "@/config";
 
-export function extractFromResource(
-  property: string,
-  resource: string
-): string {
-  const sliceLen = `/${property}/`.length;
-  const pattern = `/${property}/[^/]*`;
-  const regex = new RegExp(pattern);
-
-  const found = regex.exec(resource);
-  if (found === null) {
-    // TODO: this function doesn't support snapshots, so I have temporarily disabled errors
-    return "NOT IMPLEMENTED";
-    //throw `couldn't parse resource identifier: ${resource}`;
-  }
-
-  const result = found[0].slice(sliceLen);
-  return result;
-}
-
 export function delay(miliseconds: number) {
   return new Promise(resolve => setTimeout(resolve, miliseconds));
 }

--- a/frontend/tests/unit/recommendations.spec.ts
+++ b/frontend/tests/unit/recommendations.spec.ts
@@ -18,11 +18,17 @@ fetchMock.dontMock(); // not mocking fetch in every test by default
 
 import {
   getRecommendationProject,
-  getRecommendationResourceShortName
+  getRecommendationResourceShortName,
+  getRecommendationZone,
+  getResourcePantheonLink
 } from "@/store/data_model/recommendation_raw";
 import { RecommendationExtra } from "@/store/data_model/recommendation_extra";
 import { rootStoreFactory } from "@/store/root";
-import { freshSampleRawRecommendation } from "./sample_recommendation";
+import {
+  freshSampleRawRecommendation,
+  freshSampleSnapshotRawRecommendation,
+  freshSampleStopVMRawRecommendation
+} from "./sample_recommendation";
 
 describe("Store", () => {
   test("addRecommendation", () => {
@@ -40,17 +46,45 @@ describe("Store", () => {
   });
 });
 
-describe("Calculated properties", () => {
-  test("Getting the project that the recommendation references", () => {
-    expect(getRecommendationProject(freshSampleRawRecommendation())).toEqual(
-      "rightsizer-test"
+test("Getting the project that the recommendation references", () => {
+  expect(getRecommendationProject(freshSampleRawRecommendation())).toEqual(
+    "rightsizer-test"
+  );
+});
+
+test("Getting the instance that the recommendation references", () => {
+  expect(
+    getRecommendationResourceShortName(freshSampleRawRecommendation())
+  ).toEqual("alicja-test");
+});
+
+test("Getting the zone of the resource", () => {
+  expect(getRecommendationZone(freshSampleRawRecommendation())).toEqual(
+    "us-east1-b"
+  );
+});
+
+describe("Getting a Pantheon link for the resource", () => {
+  test("type: CHANGE_MACHINE_TYPE ", () => {
+    expect(getResourcePantheonLink(freshSampleRawRecommendation())).toEqual(
+      "https://pantheon.corp.google.com/compute/instancesDetail/zones/us-east1-b/instances/alicja-test?project=rightsizer-test"
     );
   });
 
-  test("Getting the instance that the recommendation references", () => {
+  test("type: SNAPSHOT_AND_DELETE_DISK", () => {
     expect(
-      getRecommendationResourceShortName(freshSampleRawRecommendation())
-    ).toEqual("alicja-test");
+      getResourcePantheonLink(freshSampleSnapshotRawRecommendation())
+    ).toEqual(
+      "https://pantheon.corp.google.com/compute/disksDetail/zones/europe-west1-d/disks/vertical-scaling-krzysztofk-wordpress?project=rightsizer-test"
+    );
+  });
+
+  test("type: STOP_VM", () => {
+    expect(
+      getResourcePantheonLink(freshSampleStopVMRawRecommendation())
+    ).toEqual(
+      "https://pantheon.corp.google.com/compute/instancesDetail/zones/us-central1-c/instances/timus-test-for-probers-n2-std-4-idling?project=rightsizer-test"
+    );
   });
 });
 

--- a/frontend/tests/unit/recommendations.spec.ts
+++ b/frontend/tests/unit/recommendations.spec.ts
@@ -20,7 +20,7 @@ import {
   getRecommendationProject,
   getRecommendationResourceShortName,
   getRecommendationZone,
-  getResourcePantheonLink
+  getResourceConsoleLink
 } from "@/store/data_model/recommendation_raw";
 import { RecommendationExtra } from "@/store/data_model/recommendation_extra";
 import { rootStoreFactory } from "@/store/root";
@@ -64,26 +64,26 @@ test("Getting the zone of the resource", () => {
   );
 });
 
-describe("Getting a Pantheon link for the resource", () => {
+describe("Getting a Console link for the resource", () => {
   test("type: CHANGE_MACHINE_TYPE ", () => {
-    expect(getResourcePantheonLink(freshSampleRawRecommendation())).toEqual(
-      "https://pantheon.corp.google.com/compute/instancesDetail/zones/us-east1-b/instances/alicja-test?project=rightsizer-test"
+    expect(getResourceConsoleLink(freshSampleRawRecommendation())).toEqual(
+      "https://console.cloud.google.com/compute/instancesDetail/zones/us-east1-b/instances/alicja-test?project=rightsizer-test"
     );
   });
 
   test("type: SNAPSHOT_AND_DELETE_DISK", () => {
     expect(
-      getResourcePantheonLink(freshSampleSnapshotRawRecommendation())
+      getResourceConsoleLink(freshSampleSnapshotRawRecommendation())
     ).toEqual(
-      "https://pantheon.corp.google.com/compute/disksDetail/zones/europe-west1-d/disks/vertical-scaling-krzysztofk-wordpress?project=rightsizer-test"
+      "https://console.cloud.google.com/compute/disksDetail/zones/europe-west1-d/disks/vertical-scaling-krzysztofk-wordpress?project=rightsizer-test"
     );
   });
 
   test("type: STOP_VM", () => {
     expect(
-      getResourcePantheonLink(freshSampleStopVMRawRecommendation())
+      getResourceConsoleLink(freshSampleStopVMRawRecommendation())
     ).toEqual(
-      "https://pantheon.corp.google.com/compute/instancesDetail/zones/us-central1-c/instances/timus-test-for-probers-n2-std-4-idling?project=rightsizer-test"
+      "https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-c/instances/timus-test-for-probers-n2-std-4-idling?project=rightsizer-test"
     );
   });
 });

--- a/frontend/tests/unit/sample_recommendation.ts
+++ b/frontend/tests/unit/sample_recommendation.ts
@@ -12,7 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import { RecommendationRaw } from "@/store/data_model/recommendation_raw";
+import { RecommendationRaw } from "@/store/data_model/recommendation_raw"; // --> OFF
+
+// We don't want to enforce camelCase here
+/* eslint @typescript-eslint/camelcase: 0 */
 
 const sampleRawRecommendation: RecommendationRaw = {
   content: {
@@ -24,14 +27,18 @@ const sampleRawRecommendation: RecommendationRaw = {
             path: "/machineType",
             resource:
               "//compute.googleapis.com/projects/rightsizer-test/zones/us-east1-b/instances/alicja-test",
-            resourceType: "compute.googleapis.com/Instance"
+            resourceType: "compute.googleapis.com/Instance",
+            valueMatcher: {
+              matchesPattern: ".*zones/us-east1-b/machineTypes/n1-standard-4"
+            }
           },
           {
             action: "replace",
             path: "/machineType",
             resource:
               "//compute.googleapis.com/projects/rightsizer-test/zones/us-east1-b/instances/alicja-test",
-            resourceType: "compute.googleapis.com/Instance"
+            resourceType: "compute.googleapis.com/Instance",
+            value: "zones/us-east1-b/machineTypes/custom-2-5120"
           }
         ]
       }
@@ -39,6 +46,8 @@ const sampleRawRecommendation: RecommendationRaw = {
   },
   description:
     "Save cost by changing machine type from n1-standard-4 to custom-2-5120.",
+  etag: '"da62b100443c341b"',
+  lastRefreshTime: "2020-07-13T06:41:17Z",
   name:
     "projects/323016592286/locations/us-east1-b/recommenders/google.compute.instance.MachineTypeRecommender/recommendations/6dfd692f-14b7-499a-be95-a09fe0893911",
   primaryImpact: {
@@ -46,7 +55,8 @@ const sampleRawRecommendation: RecommendationRaw = {
     costProjection: {
       cost: {
         currencyCode: "USD",
-        units: "-73"
+        nanos: 268972762,
+        units: "73"
       },
       duration: "2592000s"
     }
@@ -55,11 +65,126 @@ const sampleRawRecommendation: RecommendationRaw = {
   stateInfo: {
     state: "CLAIMED"
   }
-};
+} as RecommendationRaw;
+
+// only works for simple objects, maps and functions will be lost
+function deepCopy(obj: object): object {
+  return JSON.parse(JSON.stringify(obj));
+}
 
 export function freshSampleRawRecommendation(): RecommendationRaw {
-  // deep copy
-  return JSON.parse(
-    JSON.stringify(sampleRawRecommendation)
-  ) as RecommendationRaw;
+  return deepCopy(sampleRawRecommendation) as RecommendationRaw;
+}
+
+const sampleSnapshotRawRecommendation: RecommendationRaw = {
+  associatedInsights: [
+    {
+      insight:
+        "projects/323016592286/locations/europe-west1-d/insightTypes/google.compute.disk.IdleResourceInsight/insights/620de196-ff06-4f97-ae52-648636c98c49"
+    }
+  ],
+  content: {
+    operationGroups: [
+      {
+        operations: [
+          {
+            action: "add",
+            path: "/",
+            resource:
+              "//compute.googleapis.com/projects/rightsizer-test/global/snapshots/$snapshot-name",
+            resourceType: "compute.googleapis.com/Snapshot",
+            value: {
+              name: "$snapshot-name",
+              source_disk:
+                "projects/rightsizer-test/zones/europe-west1-d/disks/vertical-scaling-krzysztofk-wordpress",
+              storage_locations: ["europe-west1-d"]
+            }
+          },
+          {
+            action: "remove",
+            path: "/",
+            resource:
+              "//compute.googleapis.com/projects/rightsizer-test/zones/europe-west1-d/disks/vertical-scaling-krzysztofk-wordpress",
+            resourceType: "compute.googleapis.com/Disk"
+          }
+        ]
+      }
+    ]
+  },
+  description:
+    "Save cost by snapshotting and then deleting idle persistent disk 'vertical-scaling-krzysztofk-wordpress'.",
+  etag: '"856260fc666866a3"',
+  lastRefreshTime: "2020-07-17T07:00:00Z",
+  name:
+    "projects/323016592286/locations/europe-west1-d/recommenders/google.compute.disk.IdleResourceRecommender/recommendations/1e32196d-fc39-4358-9c9b-cec17a85f4ea",
+  primaryImpact: {
+    category: "COST",
+    costProjection: {
+      cost: {
+        currencyCode: "USD",
+        nanos: -135483871
+      },
+      duration: "2592000s"
+    }
+  },
+  recommenderSubtype: "SNAPSHOT_AND_DELETE_DISK",
+  stateInfo: {
+    state: "ACTIVE"
+  }
+} as RecommendationRaw;
+
+export function freshSampleSnapshotRawRecommendation(): RecommendationRaw {
+  return deepCopy(sampleSnapshotRawRecommendation) as RecommendationRaw;
+}
+
+const sampleStopVMRawRecommendation: RecommendationRaw = {
+  content: {
+    operationGroups: [
+      {
+        operations: [
+          {
+            action: "test",
+            path: "/status",
+            resource:
+              "//compute.googleapis.com/projects/rightsizer-test/zones/us-central1-c/instances/timus-test-for-probers-n2-std-4-idling",
+            resourceType: "compute.googleapis.com/Instance",
+            value: "RUNNING"
+          },
+          {
+            action: "replace",
+            path: "/status",
+            resource:
+              "//compute.googleapis.com/projects/rightsizer-test/zones/us-central1-c/instances/timus-test-for-probers-n2-std-4-idling",
+            resourceType: "compute.googleapis.com/Instance",
+            value: "TERMINATED"
+          }
+        ]
+      }
+    ]
+  },
+  description:
+    "Save cost by stopping Idle VM 'timus-test-for-probers-n2-std-4-idling'.",
+  etag: '"2e11293786a101ea"',
+  lastRefreshTime: "2020-07-17T06:36:44Z",
+  name:
+    "projects/323016592286/locations/us-central1-c/recommenders/google.compute.instance.IdleResourceRecommender/recommendations/6df88342-8116-441c-beb7-ab66d18a3078",
+  primaryImpact: {
+    category: "COST",
+    costProjection: {
+      cost: {
+        currencyCode: "USD",
+        nanos: -182895999,
+        units: "-140"
+      },
+      duration: "2592000s"
+    }
+  },
+  recommenderSubtype: "STOP_VM",
+  stateInfo: {
+    state: "ACTIVE"
+  }
+} as RecommendationRaw;
+
+export function freshSampleStopVMRawRecommendation(): RecommendationRaw {
+  return deepCopy(sampleStopVMRawRecommendation) as RecommendationRaw;
 }


### PR DESCRIPTION
Adds Pantheon links for instances and disks. Closes: #152 
It is not that easy to make a test for Pantheon links for "INCREASE_PERFORMANCE" recommendations yet (not sent by the fake service), so I have created an issue to remember about this once we integrate with the real service when this will be much easier (#153).

First four commits are small tweaks to the related code, the last one contains the actual feature.