### PR TITLE
Frontend move fetch

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -14,9 +14,6 @@ limitations under the License. -->
 
 <template>
   <div id="app">
-    <div id="nav">
-      <router-link to="/">Home</router-link>
-    </div>
     <router-view />
   </div>
 </template>
@@ -28,18 +25,5 @@ limitations under the License. -->
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-}
-
-#nav {
-  padding: 30px;
-
-  a {
-    font-weight: bold;
-    color: #2c3e50;
-
-    &.router-link-exact-active {
-      color: #42b983;
-    }
-  }
 }
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -20,16 +20,6 @@ import vuetify from "./plugins/vuetify";
 
 Vue.config.productionTip = false;
 
-/* In order for this fetch to work with the fake middleware service,
-run: `go run cmd/fake-service/*.go` first from the root folder.
-It might initially help to run it repeatedly until the installing 
-errors disappear, make sure that Go is in the latest version too. */
-
-// Asynchronously request and receive recommendations from the middleware
-store.dispatch("recommendationsStore/fetchRecommendations");
-// Start status watchers
-store.dispatch("recommendationsStore/startCentralStatusWatcher");
-
 new Vue({
   router,
   store,

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -15,6 +15,7 @@ limitations under the License. */
 import Vue from "vue";
 import VueRouter, { RouteConfig } from "vue-router";
 import Home from "../views/Home.vue";
+import store from "../store/root";
 
 Vue.use(VueRouter);
 
@@ -22,7 +23,14 @@ const routes: Array<RouteConfig> = [
   {
     path: "/",
     name: "Home",
-    component: Home
+    component: Home,
+    beforeEnter(_, __, next) {
+      // Asynchronously request and receive recommendations from the middleware
+      store.dispatch("recommendationsStore/fetchRecommendations");
+      // Start status watchers
+      store.dispatch("recommendationsStore/startCentralStatusWatcher");
+      next();
+    }
   }
 ];
 


### PR DESCRIPTION
- Starting fetching and status watchers has now been moved to router/index.ts so that they only launch when we are in the / route. This was not a problem when we had only one component, but we are about to add the permissions page which will need a new one.
- Removed the router link to / from each page (which caused the white space at the top, Fixes: #108) 