### PR TITLE
Frontend fix cost parsers

### DIFF
--- a/frontend/src/store/data_model/recommendation_extra.ts
+++ b/frontend/src/store/data_model/recommendation_extra.ts
@@ -20,7 +20,8 @@ import {
   getRecommendationCostPerWeek,
   getRecommendationProject,
   getRecommendationResourceShortName,
-  getRecommendationType
+  getRecommendationType,
+  ImpactList
 } from "./recommendation_raw";
 
 import { getInternalStatusMapping } from "./status_map";
@@ -34,6 +35,7 @@ export class RecommendationExtra implements RecommendationRaw {
   readonly primaryImpact: Impact;
   readonly content: RecommendationContent;
   readonly stateInfo: RecommendationStateInfo; // original status
+  readonly additionalImpact?: ImpactList;
 
   // need to remember them so that v-data-table knows what to sort by
   readonly costCol: number;
@@ -56,6 +58,7 @@ export class RecommendationExtra implements RecommendationRaw {
     this.primaryImpact = rec.primaryImpact;
     this.content = rec.content;
     this.stateInfo = rec.stateInfo;
+    this.additionalImpact = rec.additionalImpact;
 
     this.costCol = getRecommendationCostPerWeek(rec);
     this.projectCol = getRecommendationProject(rec);

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -21,13 +21,18 @@ export interface RecommendationRaw {
   description: string;
   recommenderSubtype: string;
   primaryImpact: Impact;
+  additionalImpact?: ImpactList;
   content: RecommendationContent;
   stateInfo: RecommendationStateInfo;
 }
 
 export interface Impact {
   category: string; // originally enum
-  costProjection: CostProjection;
+  costProjection?: CostProjection;
+}
+
+export interface ImpactList {
+  [index: number]: Impact;
 }
 
 export interface CostProjection {
@@ -69,6 +74,7 @@ export interface Operation {
   // This is a part of a union field, which other type ValueMatcher is not currently in use
   // This might well fail to parse for non-standard (not seen in recommendations now) operations
   value?: string | AddOperationValue;
+  valueMatcher?: any;
 }
 
 // Operation value used for snapshots

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -229,11 +229,11 @@ export function getRecomendationDescription(
   return recommendation.description;
 }
 
-// "3.5" ($ per week)
-export function getRecommendationCostPerWeek(
-  recommendation: RecommendationRaw
+// Get rid of duration and units/nanos representation
+export function extractCostPerWeekFromCostProjection(
+  costProjection: CostProjection
 ): number {
-  const costObject = recommendation.primaryImpact.costProjection.cost;
+  const costObject = costProjection.cost;
   console.assert(
     costObject.currencyCode === "USD",
     "Only USD supported, got %s",
@@ -242,9 +242,7 @@ export function getRecommendationCostPerWeek(
 
   // As a month doesn't have a fixed number of seconds, weekly cost is used
   // example duration: "2592000s"
-  const secs = parseInt(
-    recommendation.primaryImpact.costProjection.duration.slice(0, -1)
-  );
+  const secs = parseInt(costProjection.duration.slice(0, -1));
   // example units: "-73", example nanos: 4200000000 => -73.42
   // Sometimes we will only get the 'nanos' field
   //  (only observed for snaphshots for now)
@@ -256,6 +254,23 @@ export function getRecommendationCostPerWeek(
     cost += costObject.nanos! / (1000 * 1000 * 1000);
 
   return (cost * 60 * 60 * 24 * 7) / secs;
+}
+
+// "3.5" ($ per week)
+export function getRecommendationCostPerWeek(
+  recommendation: RecommendationRaw
+): number {
+  let costProjection: CostProjection;
+  // if "improve performance" recommendation, take from additionalImpact
+  if (recommendation.primaryImpact.category == "PERFORMANCE") {
+    costProjection = Object.values(recommendation.additionalImpact!).find(
+      (impact: Impact) => impact.category === "COST"
+    ).costProjection;
+  } else {
+    costProjection = recommendation.primaryImpact.costProjection!;
+  }
+
+  return extractCostPerWeekFromCostProjection(costProjection);
 }
 
 // "CHANGE_MACHINE_TYPE", "INCREASE_PERFORMANCE", ...

--- a/frontend/tests/unit/core_table.spec.ts
+++ b/frontend/tests/unit/core_table.spec.ts
@@ -148,8 +148,8 @@ describe("Filtering predicates individually", () => {
     expect(costFilterAccepted(tableState, extra())).toBeTruthy();
 
     // cost: -1/1000$ (this is a gain)
-    recommendation.primaryImpact.costProjection.cost.units = "0";
-    recommendation.primaryImpact.costProjection.cost.nanos = -1000000;
+    recommendation.primaryImpact.costProjection!.cost.units = "0";
+    recommendation.primaryImpact.costProjection!.cost.nanos = -1000000;
     // selected: [costs]
     tableState.costCategoriesSelected = [costCategoriesNames.costs];
     expect(costFilterAccepted(tableState, extra())).toBeFalsy();
@@ -164,8 +164,8 @@ describe("Filtering predicates individually", () => {
     expect(costFilterAccepted(tableState, extra())).toBeTruthy();
 
     // cost: 5.01$ (this is an actual cost)
-    recommendation.primaryImpact.costProjection.cost.units = "5";
-    recommendation.primaryImpact.costProjection.cost.nanos = 10 * 1000 * 1000;
+    recommendation.primaryImpact.costProjection!.cost.units = "5";
+    recommendation.primaryImpact.costProjection!.cost.nanos = 10 * 1000 * 1000;
     // selected: [costs]
     tableState.costCategoriesSelected = [costCategoriesNames.costs];
     expect(costFilterAccepted(tableState, extra())).toBeTruthy();
@@ -180,8 +180,8 @@ describe("Filtering predicates individually", () => {
     expect(costFilterAccepted(tableState, extra())).toBeTruthy();
 
     // cost: 0$
-    recommendation.primaryImpact.costProjection.cost.units = "0";
-    recommendation.primaryImpact.costProjection.cost.nanos = undefined;
+    recommendation.primaryImpact.costProjection!.cost.units = "0";
+    recommendation.primaryImpact.costProjection!.cost.nanos = undefined;
     // selected: [costs]
     tableState.costCategoriesSelected = [costCategoriesNames.costs];
     expect(costFilterAccepted(tableState, extra())).toBeTruthy();

--- a/frontend/tests/unit/recommendations.spec.ts
+++ b/frontend/tests/unit/recommendations.spec.ts
@@ -20,14 +20,16 @@ import {
   getRecommendationProject,
   getRecommendationResourceShortName,
   getRecommendationZone,
-  getResourceConsoleLink
+  getResourceConsoleLink,
+  getRecommendationCostPerWeek
 } from "@/store/data_model/recommendation_raw";
 import { RecommendationExtra } from "@/store/data_model/recommendation_extra";
 import { rootStoreFactory } from "@/store/root";
 import {
   freshSampleRawRecommendation,
   freshSampleSnapshotRawRecommendation,
-  freshSampleStopVMRawRecommendation
+  freshSampleStopVMRawRecommendation,
+  freshPerformanceRawRecommendation
 } from "./sample_recommendation";
 
 describe("Store", () => {
@@ -62,6 +64,18 @@ test("Getting the zone of the resource", () => {
   expect(getRecommendationZone(freshSampleRawRecommendation())).toEqual(
     "us-east1-b"
   );
+});
+
+test("Getting the cost of the recommendation from primaryImpact", () => {
+  expect(
+    getRecommendationCostPerWeek(freshSampleRawRecommendation())
+  ).toBeCloseTo(-17.0961);
+});
+
+test("Getting the cost of the recommendation from additionalImpact", () => {
+  expect(
+    getRecommendationCostPerWeek(freshPerformanceRawRecommendation())
+  ).toBeCloseTo(16.9);
 });
 
 describe("Getting a Console link for the resource", () => {

--- a/frontend/tests/unit/sample_recommendation.ts
+++ b/frontend/tests/unit/sample_recommendation.ts
@@ -60,8 +60,8 @@ const sampleRawRecommendation: RecommendationRaw = {
     costProjection: {
       cost: {
         currencyCode: "USD",
-        nanos: 268972762,
-        units: "73"
+        nanos: -268972762,
+        units: "-73"
       },
       duration: "2592000s"
     }
@@ -123,7 +123,17 @@ export function freshSavingRawRecommendation(): RecommendationRaw {
   return deepCopy(savingRawRecommendation) as RecommendationRaw;
 }
 
+// increase performance type (CHANGE_MACHINE_TYPE)
 const performanceRawRecommendation: RecommendationRaw = {
+  additionalImpact: [
+    {
+      category: "COST",
+      costProjection: {
+        cost: { currencyCode: "USD", nanos: 417998195, units: "72" },
+        duration: "2592000s"
+      }
+    }
+  ],
   content: {
     operationGroups: [
       {
@@ -132,38 +142,34 @@ const performanceRawRecommendation: RecommendationRaw = {
             action: "test",
             path: "/machineType",
             resource:
-              "//compute.googleapis.com/projects/rightsizer-test/zones/us-east1-b/instances/alicja-test",
-            resourceType: "compute.googleapis.com/Instance"
+              "//compute.googleapis.com/projects/rightsizer-test/zones/asia-east1-c/instances/timus-test-e2-24-cores-3",
+            resourceType: "compute.googleapis.com/Instance",
+            valueMatcher: {
+              matchesPattern:
+                ".*zones/asia-east1-c/machineTypes/e2-custom-24-98304"
+            }
           },
           {
             action: "replace",
             path: "/machineType",
             resource:
-              "//compute.googleapis.com/projects/rightsizer-test/zones/us-east1-b/instances/alicja-test",
-            resourceType: "compute.googleapis.com/Instance"
+              "//compute.googleapis.com/projects/rightsizer-test/zones/asia-east1-c/instances/timus-test-e2-24-cores-3",
+            resourceType: "compute.googleapis.com/Instance",
+            value: "zones/asia-east1-c/machineTypes/e2-custom-28-98304"
           }
         ]
       }
     ]
   },
   description:
-    "Increase performance by changing machine type from custom-2-5120 to n1-standard-4.",
+    "Improve performance by changing machine type from e2-custom-24-98304 to e2-custom-28-98304.",
+  etag: '"b64ee9c5f53fa731"',
+  lastRefreshTime: "2020-09-11T06:34:11Z",
   name:
-    "projects/323016592286/locations/us-east1-b/recommenders/google.compute.instance.MachineTypeRecommender/recommendations/6dfd6d2137-14b7-499a-be95-a09fe0893911",
-  primaryImpact: {
-    category: "COST",
-    costProjection: {
-      cost: {
-        currencyCode: "USD",
-        units: "145"
-      },
-      duration: "2592000s"
-    }
-  },
+    "projects/323016592286/locations/asia-east1-c/recommenders/google.compute.instance.MachineTypeRecommender/recommendations/1ec7145b-3f6b-44b0-89f3-778aa3c3cc46",
+  primaryImpact: { category: "PERFORMANCE" },
   recommenderSubtype: "CHANGE_MACHINE_TYPE",
-  stateInfo: {
-    state: "CLAIMED"
-  }
+  stateInfo: { state: "ACTIVE" }
 } as RecommendationRaw;
 
 export function freshPerformanceRawRecommendation(): RecommendationRaw {


### PR DESCRIPTION
- "improve performance" recommendations have their cost computed properly now
- there used to be no tests for cost parsers, so added two for recommendations with cost in primaryImpact and additionalImpact respectively