### PR TITLE
Frontend safer parsing

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -13,6 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 export class ProjectConfig {
-  public static DEVELOPMENT_SERVER_ADDRESS = "http://localhost:8000";
-  public static PRODUCTION_SERVER_ADDRESS = "";
+  public static DEVELOPMENT_BACKEND_ADDRESS = "http://localhost:8078";
+  public static PRODUCTION_BACKEND_ADDRESS = "";
+}
+
+export function getBackendAddress(): string {
+  return process.env.NODE_ENV === "development"
+    ? ProjectConfig.DEVELOPMENT_BACKEND_ADDRESS
+    : ProjectConfig.PRODUCTION_BACKEND_ADDRESS;
 }

--- a/frontend/src/store/data_model/recommendation_extra.ts
+++ b/frontend/src/store/data_model/recommendation_extra.ts
@@ -36,13 +36,13 @@ export class RecommendationExtra implements RecommendationRaw {
   readonly stateInfo: RecommendationStateInfo; // original status
 
   // need to remember them so that v-data-table knows what to sort by
-  readonly costCol: number;
-  readonly projectCol: string;
-  readonly resourceCol: string;
-  readonly typeCol: string;
+  readonly costCol: number = 0;
+  readonly projectCol: string = "Undefined";
+  readonly resourceCol: string = "Undefined";
+  readonly typeCol: string = "Undefined";
 
   // These can be modified:
-  statusCol: string; // follows the current recommendation status, unlike stateInfo
+  statusCol = "Undefined"; // follows the current recommendation status, unlike stateInfo
   errorHeader?: string; // if apply fails,
   errorDescription?: string; // error details are stored here
 
@@ -57,12 +57,18 @@ export class RecommendationExtra implements RecommendationRaw {
     this.content = rec.content;
     this.stateInfo = rec.stateInfo;
 
-    this.costCol = getRecommendationCostPerWeek(rec);
-    this.projectCol = getRecommendationProject(rec);
-    this.resourceCol = getRecommendationResourceShortName(rec);
-    this.typeCol = getRecommendationType(rec);
-    this.statusCol = getInternalStatusMapping(rec.stateInfo.state);
-    this.needsStatusWatcher =
-      this.statusCol === getInternalStatusMapping("CLAIMED");
+    // let's make sure that even if we make an invalid assumption in
+    // one of the parsers, we don't kill the app
+    try {
+      this.costCol = getRecommendationCostPerWeek(rec);
+      this.projectCol = getRecommendationProject(rec);
+      this.resourceCol = getRecommendationResourceShortName(rec);
+      this.typeCol = getRecommendationType(rec);
+      this.statusCol = getInternalStatusMapping(rec.stateInfo.state);
+      this.needsStatusWatcher =
+        this.statusCol === getInternalStatusMapping("CLAIMED");
+    } catch (err) {
+      console.log([`Failed to parse recommendation: Continuing.`, err, rec]);
+    }
   }
 }

--- a/frontend/src/store/recommendations.ts
+++ b/frontend/src/store/recommendations.ts
@@ -14,14 +14,15 @@ limitations under the License. */
 
 import { RecommendationRaw } from "@/store/data_model/recommendation_raw";
 import { RecommendationExtra } from "@/store/data_model/recommendation_extra";
-import { delay, getServerAddress } from "./utils/misc";
+import { delay } from "./utils/misc";
 import { getInternalStatusMapping } from "@/store/data_model/status_map";
 import { Module, MutationTree, ActionTree, GetterTree } from "vuex";
 import { IRootStoreState } from "./root";
+import { getBackendAddress } from "../config";
 import { similaritySort, trainingDataHandler } from "./smart_sort/similarity";
 
 // TODO: move all of this to config in some next PR
-const SERVER_ADDRESS: string = getServerAddress();
+const BACKEND_ADDRESS: string = getBackendAddress();
 const FETCH_PROGRESS_WAIT_TIME = 100; // (1/10)s
 const APPLY_PROGRESS_WAIT_TIME = 10000; // 10s
 const HTTP_OK_CODE = 200;
@@ -117,7 +118,7 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
     // send /recommendations requests until data received
     let responseJson: any;
     for (;;) {
-      const response = await fetch(`${SERVER_ADDRESS}/recommendations`);
+      const response = await fetch(`${BACKEND_ADDRESS}/recommendations`);
       responseJson = await response.json();
       const responseCode = response.status;
 
@@ -194,7 +195,7 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
     });
 
     const response = await fetch(
-      `${SERVER_ADDRESS}/recommendations/apply?name=${rec.name}`,
+      `${BACKEND_ADDRESS}/recommendations/apply?name=${rec.name}`,
       { method: "POST" }
     );
 
@@ -259,7 +260,7 @@ const actions: ActionTree<IRecommendationsStoreState, IRootStoreState> = {
   ): Promise<boolean> {
     // send the request
     const response = await fetch(
-      `${SERVER_ADDRESS}/recommendations/checkStatus?name=${rec.name}`
+      `${BACKEND_ADDRESS}/recommendations/checkStatus?name=${rec.name}`
     );
 
     // handle all possible types of responses

--- a/frontend/src/store/utils/misc.ts
+++ b/frontend/src/store/utils/misc.ts
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import { ProjectConfig } from "@/config";
-
 export function delay(miliseconds: number) {
   return new Promise(resolve => setTimeout(resolve, miliseconds));
-}
-
-export function getServerAddress(): string {
-  if (process.env.NODE_ENV === "development") {
-    return ProjectConfig.DEVELOPMENT_SERVER_ADDRESS;
-  }
-
-  return ProjectConfig.PRODUCTION_SERVER_ADDRESS;
 }


### PR DESCRIPTION
- We observed that one problem with parsing costs for "improve performance" recommendations made the whole app unusable, let's make sure that this doesn't happen again by wrapping the parsers in a try/catch block and printing the errors to the console instead.
- Changed the name of the backend address constant to reflect the fact that it is an address for backend not frontend (as this address would also make sense now in the context of this project). It is also better if the helper function is near the config, as this makes it much more local (although, it is best if we move these constants outside of src/ and into a proper constants-only config file at some point)