### PR TITLE
Two issues related to resource links

### DIFF
--- a/frontend/src/components/ResourceCell.vue
+++ b/frontend/src/components/ResourceCell.vue
@@ -13,7 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License. -->
 <template>
   <div>
-    <a :href="consoleLink"> {{ shortName }} </a>
+    <!-- Stackoverflow points to a potential security problem with opening the
+         link in a new tab; the newly opened tab will have access to our data. 
+         As long as the link is to Google Console, this shouldn't be a problem. 
+         Related Stackoverflow question:
+         https://stackoverflow.com/questions/17711146/how-to-open-link-in-new-tab-on-html 
+    -->
+    <a :href="consoleLink" target="_blank" rel="noopener noreferrer">
+      {{ shortName }}
+    </a>
   </div>
 </template>
 <script lang="ts">

--- a/frontend/src/store/data_model/recommendation_raw.ts
+++ b/frontend/src/store/data_model/recommendation_raw.ts
@@ -261,7 +261,7 @@ export function getRecommendationZone(recommendation: RecommendationRaw) {
   const type = getRecommendationType(recommendation);
   let resource: string;
 
-  // First resource for instances, second for snapshots
+  // Only snapshots have the main resource as second
   if (type === "SNAPSHOT_AND_DELETE_DISK")
     resource = getRecommendationSecondResource(recommendation);
   else resource = getRecommendationFirstResource(recommendation);
@@ -275,7 +275,9 @@ export function getResourceConsoleLink(recommendation: RecommendationRaw) {
   const shortName = getRecommendationResourceShortName(recommendation);
   const type = getRecommendationType(recommendation);
   switch (type) {
-    case "SNAPSHOT_AND_DELETE_DISK": // disks
+    // disks
+    case "SNAPSHOT_AND_DELETE_DISK":
+    case "DELETE_DISK":
       return `https://console.cloud.google.com/compute/disksDetail/zones/${zone}/disks/${shortName}?project=${project}`;
     default:
       // instances

--- a/frontend/tests/unit/recommendations.spec.ts
+++ b/frontend/tests/unit/recommendations.spec.ts
@@ -27,7 +27,8 @@ import { rootStoreFactory } from "@/store/root";
 import {
   freshSampleRawRecommendation,
   freshSampleSnapshotRawRecommendation,
-  freshSampleStopVMRawRecommendation
+  freshSampleStopVMRawRecommendation,
+  freshSampleDeleteDiskRawRecommendation
 } from "./sample_recommendation";
 
 describe("Store", () => {
@@ -58,7 +59,8 @@ test("Getting the instance that the recommendation references", () => {
   ).toEqual("alicja-test");
 });
 
-test("Getting the zone of the resource", () => {
+// zones are already tested by the tests for links, so they don't need to be as thorough
+test("Getting the zone of the resource for CHANGE_MACHINE_TYPE", () => {
   expect(getRecommendationZone(freshSampleRawRecommendation())).toEqual(
     "us-east1-b"
   );
@@ -76,6 +78,14 @@ describe("Getting a Console link for the resource", () => {
       getResourceConsoleLink(freshSampleSnapshotRawRecommendation())
     ).toEqual(
       "https://console.cloud.google.com/compute/disksDetail/zones/europe-west1-d/disks/vertical-scaling-krzysztofk-wordpress?project=rightsizer-test"
+    );
+  });
+
+  test("type: DELETE_DISK", () => {
+    expect(
+      getResourceConsoleLink(freshSampleDeleteDiskRawRecommendation())
+    ).toEqual(
+      "https://console.cloud.google.com/compute/disksDetail/zones/us-central1-a/disks/stanislawm-test-1?project=rightsizer-test"
     );
   });
 

--- a/frontend/tests/unit/sample_recommendation.ts
+++ b/frontend/tests/unit/sample_recommendation.ts
@@ -282,3 +282,43 @@ const sampleStopVMRawRecommendation: RecommendationRaw = {
 export function freshSampleStopVMRawRecommendation(): RecommendationRaw {
   return deepCopy(sampleStopVMRawRecommendation) as RecommendationRaw;
 }
+
+const sampleDeleteDiskRecommendation: RecommendationRaw = {
+  name:
+    "projects/323016592286/locations/us-central1-a/recommenders/google.compute.disk.IdleResourceRecommender/recommendations/33d373d1-e6ad-45b8-991a-83d9dcdb5ea5",
+  description:
+    "Save cost by deleting idle persistent disk 'stanislawm-test-1'.",
+  recommenderSubtype: "DELETE_DISK",
+  primaryImpact: {
+    category: "COST",
+    costProjection: {
+      cost: {
+        currencyCode: "USD",
+        nanos: -400000000
+      },
+      duration: "2592000s"
+    }
+  },
+  content: {
+    operationGroups: [
+      {
+        operations: [
+          {
+            action: "remove",
+            path: "/",
+            resource:
+              "//compute.googleapis.com/projects/rightsizer-test/zones/us-central1-a/disks/stanislawm-test-1",
+            resourceType: "compute.googleapis.com/Disk"
+          }
+        ]
+      }
+    ]
+  },
+  stateInfo: {
+    state: "ACTIVE"
+  }
+} as RecommendationRaw;
+
+export function freshSampleDeleteDiskRawRecommendation(): RecommendationRaw {
+  return deepCopy(sampleDeleteDiskRecommendation) as RecommendationRaw;
+}


### PR DESCRIPTION
- DELETE_DISK recommendations now have proper links (used to point to instances-like address)
- we want to open resource links in a new tab by default, it is way too easy to left-click it by mistake and to close the Recomator (restarting may take a really long time). 