### PR TITLE
Fix broken footer test: fetch needs to be disabled

### DIFF
--- a/frontend/tests/unit/footer.spec.ts
+++ b/frontend/tests/unit/footer.spec.ts
@@ -11,6 +11,11 @@ import {
 import vuetify from "@/plugins/vuetify";
 import { Store } from "vuex";
 
+// We want all fetches to be mocked to do nothing here, 
+//  so that tests do not depenend on network requests
+import { enableFetchMocks } from "jest-fetch-mock";
+enableFetchMocks();
+
 describe("Footer", () => {
   let recommendation: RecommendationExtra;
   let savingRecommendation: RecommendationExtra;

--- a/frontend/tests/unit/footer.spec.ts
+++ b/frontend/tests/unit/footer.spec.ts
@@ -11,7 +11,7 @@ import {
 import vuetify from "@/plugins/vuetify";
 import { Store } from "vuex";
 
-// We want all fetches to be mocked to do nothing here, 
+// We want all fetches to be mocked to do nothing here,
 //  so that tests do not depenend on network requests
 import { enableFetchMocks } from "jest-fetch-mock";
 enableFetchMocks();


### PR DESCRIPTION
One of the footer tests was broken, as it clicked the "Apply" buttons which triggered network requests (fetches).

The build didn't fail for the past few PRs to master because the error was in an async function, so only a warning which wrapped the error was shown. You can see it in build logs, for example: https://github.com/googleinterns/recomator/runs/1100333400 - open npm run test:unit.

The error:
 
`(node:2906) UnhandledPromiseRejectionWarning: ReferenceError: fetch is not defined
(Use `node --trace-warnings ...` to show where the warning was created)
(node:2906) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:2906) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`

Fetch is now mocked in the whole file (does nothing). 
Fixes: #171 