### PR TITLE
Progress bar made more visible now

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -24,6 +24,7 @@ limitations under the License. -->
           dark
           style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);"
           v-if="$store.state.recommendationsStore.progress !== null"
+          data-name="main_progress_bar"
           hide-overlay
           persistent
           width="300"

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -18,30 +18,28 @@ limitations under the License. -->
       <h1>Recomator</h1>
     </v-app-bar>
     <v-main>
-      <div class="text-center">
-        <v-card
-          color="primary"
-          dark
-          style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);"
-          v-if="$store.state.recommendationsStore.progress !== null"
-          data-name="main_progress_bar"
-          hide-overlay
-          persistent
-          width="300"
-        >
-          <v-card-title class="justify-center">
-            Loading recommendations...
-          </v-card-title>
-          <v-card-text>
-            <v-progress-linear
-              color="white"
-              :indeterminate="$store.state.recommendationsStore.progress === 0"
-              :value="$store.state.recommendationsStore.progress"
-              class="mb-0"
-            ></v-progress-linear>
-          </v-card-text>
-        </v-card>
-      </div>
+      <v-card
+        color="primary"
+        dark
+        id="progressBar"
+        v-if="$store.state.recommendationsStore.progress !== null"
+        data-name="main_progress_bar"
+        hide-overlay
+        persistent
+        width="300"
+      >
+        <v-card-title class="justify-center">
+          Loading recommendations...
+        </v-card-title>
+        <v-card-text>
+          <v-progress-linear
+            color="white"
+            :indeterminate="$store.state.recommendationsStore.progress === 0"
+            :value="$store.state.recommendationsStore.progress"
+            class="mb-0"
+          ></v-progress-linear>
+        </v-card-text>
+      </v-card>
       <v-container
         fluid
         data-name="main_container"
@@ -68,3 +66,12 @@ import Footer from "@/components/Footer.vue";
 })
 export default class Home extends Vue {}
 </script>
+
+<style lang="scss">
+#progressBar {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -18,14 +18,29 @@ limitations under the License. -->
       <h1>Recomator</h1>
     </v-app-bar>
     <v-main>
-      <v-progress-linear
-        :value="$store.state.recommendationsStore.progress"
-        data-name="main_progress_bar"
-        :indeterminate="$store.state.recommendationsStore.progress === 0"
-        height="10"
-        color="info"
-        v-if="$store.state.recommendationsStore.progress !== null"
-      />
+      <div class="text-center">
+        <v-card
+          color="primary"
+          dark
+          style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);"
+          v-if="$store.state.recommendationsStore.progress !== null"
+          hide-overlay
+          persistent
+          width="300"
+        >
+          <v-card-title class="justify-center">
+            Loading recommendations...
+          </v-card-title>
+          <v-card-text>
+            <v-progress-linear
+              color="white"
+              :indeterminate="$store.state.recommendationsStore.progress === 0"
+              :value="$store.state.recommendationsStore.progress"
+              class="mb-0"
+            ></v-progress-linear>
+          </v-card-text>
+        </v-card>
+      </div>
       <v-container
         fluid
         data-name="main_container"

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -21,6 +21,9 @@ limitations under the License. -->
       <v-progress-linear
         :value="$store.state.recommendationsStore.progress"
         data-name="main_progress_bar"
+        :indeterminate="$store.state.recommendationsStore.progress === 0"
+        height="10"
+        color="info"
         v-if="$store.state.recommendationsStore.progress !== null"
       />
       <v-container


### PR DESCRIPTION
- If progress is 0 (which currently usually happens for a few seconds), the progress bar is set to the indeterminate mode so that the user knows that something is happening instead of seeing a nearly blank screen.
- ~~Changed the colour of the progress bar so that it doesn't match and blend in with the app bar~~
- We display "loading recommendations..." to help the user understand what is actually loading

First version (first commit): https://screencast.googleplex.com/cast/NDYzNjYwNjE4MDg4NDQ4MHw5OWM5ZTExOS0zZg
Second version (second commit): https://screencast.googleplex.com/cast/NTkwMzExNzkzNTcwNjExMnxiMjgxODQxOC0wYw
Looks okay on a mobile as well:
![Screenshot 2020-09-17 at 5 27 02 PM](https://user-images.githubusercontent.com/7630347/93499621-22ade680-f90b-11ea-8504-062de995d0b7.png)


Closes: #179 

