### PR TITLE
New reusable progress + header component

### DIFF
--- a/frontend/src/components/ProgressWithHeader.vue
+++ b/frontend/src/components/ProgressWithHeader.vue
@@ -1,0 +1,63 @@
+<!-- Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+<template>
+  <v-card color="primary" dark id="progressBar" persistent width="300">
+    <v-card-title class="justify-center">
+      {{ header }}
+    </v-card-title>
+    <v-card-text>
+      <v-progress-linear
+        color="white"
+        :indeterminate="indeterminate"
+        :value="progress"
+        class="mb-0"
+      ></v-progress-linear>
+    </v-card-text>
+  </v-card>
+</template>
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+const ProgressWithHeaderProps = Vue.extend({
+  props: {
+    progress: {
+      type: Number,
+      required: true
+    },
+    header: {
+      type: String,
+      required: true
+    }
+  }
+});
+
+@Component
+export default class ProgressWithHeader extends ProgressWithHeaderProps {
+  // progress tends to be 0 for the first few seconds, therefore we first show
+  // the progress bar in the indeterminate state (progress animation independent of actual progress)
+  get indeterminate(): boolean {
+    return this.progress === 0;
+  }
+}
+</script>
+
+<style lang="scss">
+#progressBar {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -18,28 +18,12 @@ limitations under the License. -->
       <h1>Recomator</h1>
     </v-app-bar>
     <v-main>
-      <v-card
-        color="primary"
-        dark
-        id="progressBar"
+      <ProgressWithHeader
         v-if="$store.state.recommendationsStore.progress !== null"
+        :progress="$store.state.recommendationsStore.progress"
+        header="Loading recommendations..."
         data-name="main_progress_bar"
-        hide-overlay
-        persistent
-        width="300"
-      >
-        <v-card-title class="justify-center">
-          Loading recommendations...
-        </v-card-title>
-        <v-card-text>
-          <v-progress-linear
-            color="white"
-            :indeterminate="$store.state.recommendationsStore.progress === 0"
-            :value="$store.state.recommendationsStore.progress"
-            class="mb-0"
-          ></v-progress-linear>
-        </v-card-text>
-      </v-card>
+      />
       <v-container
         fluid
         data-name="main_container"
@@ -60,18 +44,10 @@ limitations under the License. -->
 import { Component, Vue } from "vue-property-decorator";
 import CoreTable from "@/components/CoreTable.vue";
 import Footer from "@/components/Footer.vue";
+import ProgressWithHeader from "@/components/ProgressWithHeader.vue";
 
 @Component({
-  components: { CoreTable, Footer }
+  components: { CoreTable, Footer, ProgressWithHeader }
 })
 export default class Home extends Vue {}
 </script>
-
-<style lang="scss">
-#progressBar {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-</style>


### PR DESCRIPTION
The progress bar for fetching recommendations has just been moved to its own component.
This is done so that other operations, like fetching projects or requirements, can reuse it.
Closes: #198 