### PR TITLE
Added styling to avoid line breaking

### DIFF
--- a/frontend/src/components/ApplyAndStatusCell.vue
+++ b/frontend/src/components/ApplyAndStatusCell.vue
@@ -81,6 +81,14 @@ limitations under the License. -->
     </v-dialog>
   </div>
 </template>
+
+<style>
+.v-card__text,
+.v-card__title {
+  word-break: normal;
+}
+</style>
+
 <script lang="ts">
 import Vue, { PropType } from "vue";
 import { Component } from "vue-property-decorator";


### PR DESCRIPTION
Before:
![Screenshot 2020-09-23 at 11 56 25 AM](https://user-images.githubusercontent.com/46993440/94112679-19aaa100-fe46-11ea-8b84-0f44477b5aec.png)
After:
![Screenshot 2020-09-23 at 2 05 03 PM](https://user-images.githubusercontent.com/46993440/94112710-2202dc00-fe46-11ea-9ba8-661e0d26ae10.png)
 I wasn't able to get breaking lines in the text of the error. Moreover, both errors that we have in the recommendations right now are empty.