### PR TITLE
Fix: Navigation exceptions in the console

### DIFF
--- a/frontend/src/components/AppBar.vue
+++ b/frontend/src/components/AppBar.vue
@@ -23,11 +23,12 @@ limitations under the License. -->
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import { betterPush } from "./../router/better_push";
 
 @Component({})
 export default class AppBar extends Vue {
   getHomePage() {
-    this.$router.push({ name: "Home" });
+    betterPush(this.$router, "Home");
   }
 }
 </script>

--- a/frontend/src/components/ProjectList.vue
+++ b/frontend/src/components/ProjectList.vue
@@ -112,6 +112,7 @@ limitations under the License. -->
 import { Component, Vue } from "vue-property-decorator";
 import { IRootStoreState } from "../store/root_state";
 import { Project } from "../store/data_model/project";
+import { betterPush } from "./../router/better_push";
 
 @Component({})
 export default class ProjectList extends Vue {
@@ -156,12 +157,12 @@ export default class ProjectList extends Vue {
 
   getRequirements() {
     this.$store.dispatch("projectsStore/saveSelectedProjects");
-    this.$router.push("requirements");
+    betterPush(this.$router, "Requirements");
   }
 
   getRecommendations() {
     this.$store.dispatch("projectsStore/saveSelectedProjects");
-    this.$router.push("homeWithInit");
+    betterPush(this.$router, "HomeWithInit");
   }
 }
 </script>

--- a/frontend/src/components/ProjectsWithRequirements.vue
+++ b/frontend/src/components/ProjectsWithRequirements.vue
@@ -85,6 +85,7 @@ table th + th {
 import { Component, Vue } from "vue-property-decorator";
 import { IRootStoreState } from "../store/root_state";
 import { ProjectRequirement } from "../store/data_model/project_with_requirements";
+import { betterPush } from "./../router/better_push";
 
 @Component({})
 export default class ProjectList extends Vue {
@@ -124,7 +125,7 @@ export default class ProjectList extends Vue {
   }
 
   getProjects() {
-    this.$router.push("projects");
+    betterPush(this.$router, "Projects");
   }
 }
 </script>

--- a/frontend/src/router/better_push.ts
+++ b/frontend/src/router/better_push.ts
@@ -1,0 +1,25 @@
+/* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import VueRouter from "vue-router";
+
+// VueRouter returns errors during router.push(*) if we redirect (using, let's say next) during
+// the navigation, as apparently (the Vue.js team member claims) it is a potentially buggy case.
+// That is why router-link passes an empty function as onComplete to router.push, as this changes the
+// behaviour of router not to return a Promise
+export function betterPush(router: VueRouter, routeName: string) {
+  router.push({ name: routeName }, undefined, err => {
+    console.log("Navigation warning:", err);
+  });
+}

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -58,13 +58,14 @@ import AppBar from "@/components/AppBar.vue";
 import CoreTable from "@/components/CoreTable.vue";
 import Footer from "@/components/Footer.vue";
 import ProgressWithHeader from "@/components/ProgressWithHeader.vue";
+import { betterPush } from "./../router/better_push";
 
 @Component({
   components: { CoreTable, Footer, ProgressWithHeader, AppBar }
 })
 export default class Home extends Vue {
   getProjectSelection() {
-    this.$router.push("projectsWithInit");
+    betterPush(this.$router, "ProjectsWithInit");
   }
 }
 </script>

--- a/frontend/src/views/Requirements.vue
+++ b/frontend/src/views/Requirements.vue
@@ -55,13 +55,14 @@ import { Component, Vue } from "vue-property-decorator";
 import ProjectsWithRequirements from "@/components/ProjectsWithRequirements.vue";
 import AppBar from "@/components/AppBar.vue";
 import ProgressWithHeader from "@/components/ProgressWithHeader.vue";
+import { betterPush } from "./../router/better_push";
 
 @Component({
   components: { ProjectsWithRequirements, ProgressWithHeader, AppBar }
 })
 export default class Requirements extends Vue {
   getProjectSelection() {
-    this.$router.push("projects");
+    betterPush(this.$router, "Projects");
   }
 }
 </script>


### PR DESCRIPTION
We used to see errors like these whenever `router.push` was used and the route handler redirected somewhere else:
![Screenshot 2020-09-24 at 8 43 03 PM](https://user-images.githubusercontent.com/7630347/94199189-557a5080-feb0-11ea-89ed-d8146c7998ea.png)
From what I read, these are not actually errors in the sense that we are using the Vue Router wrong. They are just hints that this *might* not be intended. Apparently, `<router-link>` implementation uses `router.push` in a way that just ignores these errors. I chose to just put them in the console, but not as red errors but as gray warnings. 

After:
![Screenshot 2020-09-24 at 10 01 35 PM](https://user-images.githubusercontent.com/7630347/94200052-afc7e100-feb1-11ea-9424-b8a588061bbe.png)

Fixes: #210 
